### PR TITLE
shellcheck: Make all bash scripts pass shellcheck

### DIFF
--- a/build/IPDK_Container/Makefile
+++ b/build/IPDK_Container/Makefile
@@ -54,3 +54,5 @@ prune: ;docker system prune
 
 ## Create a volume and then configure the container to use it.
 volume: ;docker volume create shared; docker run --rm --cap-add ALL --privileged -v shared:/tmp -it ${IMAGE_NAME}:${TAG}
+
+shellcheck: ;shellcheck -x `find . -name "*.sh"`

--- a/build/IPDK_Container/Ubuntu20.04/Makefile
+++ b/build/IPDK_Container/Ubuntu20.04/Makefile
@@ -54,3 +54,5 @@ prune: ;docker system prune
 
 ## Create a volume and then configure the container to use it.
 volume: ;docker volume create shared; docker run --rm --cap-add ALL --privileged -v shared:/tmp -it ${IMAGE_NAME}:${TAG}
+
+shellcheck: ;shellcheck -x `find . -name "*.sh"`

--- a/build/IPDK_Container/examples/vhost-to-vhost/build_ubuntu_vm_image.sh
+++ b/build/IPDK_Container/examples/vhost-to-vhost/build_ubuntu_vm_image.sh
@@ -1,7 +1,6 @@
+#!/bin/bash
 #Copyright (C) 2021 Intel Corporation
 #SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash
 
 #Download Ubuntu 20.04 image
 sudo wget -O /var/lib/libvirt/images/ http://releases.ubuntu.com/20.04/ubuntu-20.04.3-live-server-amd64.iso

--- a/build/IPDK_Container/examples/vhost-to-vhost/start_vm.sh
+++ b/build/IPDK_Container/examples/vhost-to-vhost/start_vm.sh
@@ -14,7 +14,7 @@ QEMU=qemu-kvm
 ${QEMU} -smp 4 -m 4096M \
     -boot c -cpu host -enable-kvm -nographic \
     -L /root/pc-bios -name VM1_TAP_DEV \
-    -hda ${QCOW2_IMAG_PATH_VM1} \
+    -hda "${QCOW2_IMAG_PATH_VM1}" \
     -object memory-backend-file,id=mem,size=4096M,mem-path=/dev/hugepages,share=on \
     -mem-prealloc \
     -numa node,memdev=mem \
@@ -26,7 +26,7 @@ ${QEMU} -smp 4 -m 4096M \
 ${QEMU} -smp 4 -m 4096M \
     -boot c -cpu host -enable-kvm -nographic \
     -L /root/pc-bios -name VM1_TAP_DEV \
-    -hda ${QCOW2_IMAG_PATH_VM2} \
+    -hda "${QCOW2_IMAG_PATH_VM2}" \
     -object memory-backend-file,id=mem,size=4096M,mem-path=/dev/hugepages,share=on \
     -mem-prealloc \
     -numa node,memdev=mem \

--- a/build/IPDK_Container/examples/vhost-to-vhost/start_vm.sh
+++ b/build/IPDK_Container/examples/vhost-to-vhost/start_vm.sh
@@ -3,8 +3,9 @@
 #SPDX-License-Identifier: Apache-2.0
 
 #QCOW2 IMAGES PATH...#
-QCOW2_IMAG_PATH_VM1=<IMAGE1>.img
-QCOW2_IMAG_PATH_VM2=<IMAGE2>.img
+# Note: Adjust to the names of the actual images you want to use
+QCOW2_IMAG_PATH_VM1=example1.img
+QCOW2_IMAG_PATH_VM2=example2img
 
 # application to run the Qemu KVM in Fedora.
 QEMU=qemu-kvm

--- a/build/IPDK_Container/scripts/build_p4c.sh
+++ b/build/IPDK_Container/scripts/build_p4c.sh
@@ -1,9 +1,9 @@
+#!/usr/bin/bash
 #Copyright (C) 2021 Intel Corporation
 #SPDX-License-Identifier: Apache-2.0
 
-#!/usr/bin/bash
-
 set -e
+# shellcheck source=scripts/os_ver_details.sh
 source os_ver_details.sh
 
 if [ -z "$1" ]
@@ -17,12 +17,12 @@ fi
 P4C_SHA=d2f0c2a22286c6b6643e5e3906cf020d6d698c70
 
 WORKDIR=$1
-cd $WORKDIR
+cd "$WORKDIR"
 
 echo "Removing P4C directory if it already exits"
 if [ -d "P4C" ]; then rm -Rf P4C; fi
 echo "Cloning  P4C repo"
-cd $WORKDIR
+cd "$WORKDIR"
 
 #Read the number of CPUs in a system and derive the NUM threads
 get_num_cores

--- a/build/IPDK_Container/scripts/build_p4sde.sh
+++ b/build/IPDK_Container/scripts/build_p4sde.sh
@@ -31,7 +31,7 @@ export SDE=${PWD}
 export SDE_INSTALL=$SDE/install
 
 #...Package Config Path...#
-if [ "${OS}" = "Ubuntu" ] || "${VER}" = "20.04"; then
+if [ "${OS}" = "Ubuntu" ]  || [ "${VER}" = "20.04" ] ; then
     export PKG_CONFIG_PATH=${SDE_INSTALL}/lib/x86_64-linux-gnu/pkgconfig
 else
     export PKG_CONFIG_PATH=${SDE_INSTALL}/lib64/pkgconfig

--- a/build/IPDK_Container/scripts/build_p4sde.sh
+++ b/build/IPDK_Container/scripts/build_p4sde.sh
@@ -4,6 +4,7 @@
 
 set -e
 
+# shellcheck source=scripts/os_ver_details.sh
 source os_ver_details.sh
 get_os_ver_details
 
@@ -19,11 +20,11 @@ git config --global url."https://github.com/".insteadOf git@github.com:
 git config --global url."https://".insteadOf git://
 
 WORKDIR=$1
-cd ${WORKDIR}
+cd "${WORKDIR}" || exit
 
 echo "Removing p4-sde directory if it already exists"
 if [ -d "p4-sde" ]; then rm -Rf p4-sde; fi
-mkdir $1/p4-sde && cd $1/p4-sde
+mkdir "$1"/p4-sde && cd "$1"/p4-sde || exit
 #..Setting Environment Variables..#
 echo "Exporting Environment Variables....."
 export SDE=${PWD}
@@ -43,16 +44,16 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 echo "SDE environment variable"
-echo $SDE
-echo $SDE_INSTALL
-echo $PKG_CONFIG_PATH
+echo "$SDE"
+echo "$SDE_INSTALL"
+echo "$PKG_CONFIG_PATH"
 
 #Read the number of CPUs in a system and derive the NUM threads
 get_num_cores
 echo "Number of Parallel threads used: $NUM_THREADS ..."
 echo ""
 
-cd $SDE
+cd "$SDE" || exit
 echo "Removing p4-driver repository if it already exists"
 if [ -d "p4-driver" ]; then rm -Rf p4-driver; fi
 echo "Compiling p4-driver"
@@ -66,12 +67,12 @@ if [ "${OS}" = "Ubuntu" ]; then
 fi
 python3 install_dep.py
 
-cd $SDE/p4-driver
+cd "$SDE/p4-driver" || exit
 ./autogen.sh
-./configure --prefix=$SDE_INSTALL
+./configure --prefix="$SDE_INSTALL"
 make clean
-make $NUM_THREADS
-make $NUM_THREADS install
+make "$NUM_THREADS"
+make "$NUM_THREADS" install
 ldconfig
 
 set +e

--- a/build/IPDK_Container/scripts/build_p4sde.sh
+++ b/build/IPDK_Container/scripts/build_p4sde.sh
@@ -24,11 +24,11 @@ cd "${WORKDIR}" || exit
 
 echo "Removing p4-sde directory if it already exists"
 if [ -d "p4-sde" ]; then rm -Rf p4-sde; fi
-mkdir "$1"/p4-sde && cd "$1"/p4-sde || exit
+mkdir "$1/p4-sde" && cd "$1/p4-sde" || exit
 #..Setting Environment Variables..#
 echo "Exporting Environment Variables....."
-export SDE=${PWD}
-export SDE_INSTALL=$SDE/install
+export SDE="${PWD}"
+export SDE_INSTALL="$SDE/install"
 
 #...Package Config Path...#
 if [ "${OS}" = "Ubuntu" ]  || [ "${VER}" = "20.04" ] ; then
@@ -71,8 +71,8 @@ cd "$SDE/p4-driver" || exit
 ./autogen.sh
 ./configure --prefix="$SDE_INSTALL"
 make clean
-make "$NUM_THREADS"
-make "$NUM_THREADS" install
+make $NUM_THREADS
+make $NUM_THREADS install
 ldconfig
 
 set +e

--- a/build/IPDK_Container/scripts/get_p4ovs_repo.sh
+++ b/build/IPDK_Container/scripts/get_p4ovs_repo.sh
@@ -1,7 +1,6 @@
+#!/usr/bin/bash
 #Copyright (C) 2021 Intel Corporation
 #SPDX-License-Identifier: Apache-2.0
-
-#!/usr/bin/bash
 
 if [ -z "$1" ]
 then
@@ -12,9 +11,9 @@ fi
 
 WORKDIR=$1
 
-cd $WORKDIR
+cd "$WORKDIR" || exit
 echo "Removing P4-OVS directory if it already exits"
 if [ -d "P4-OVS" ]; then rm -Rf P4-OVS; fi
 echo "Cloning P4-OVS repo"
-cd $WORKDIR
+cd "$WORKDIR" || exit
 git clone https://github.com/ipdk-io/ovs.git -b ovs-with-p4 --recursive P4-OVS

--- a/build/IPDK_Container/scripts/os_ver_details.sh
+++ b/build/IPDK_Container/scripts/os_ver_details.sh
@@ -8,6 +8,7 @@ get_os_ver_details()
 {
   if [ -f /etc/os-release ]; then
       # freedesktop.org and systemd
+      # shellcheck source=/dev/null
       . /etc/os-release
       OS=$NAME
       VER=$VERSION_ID
@@ -17,6 +18,7 @@ get_os_ver_details()
       VER=$(lsb_release -sr)
   elif [ -f /etc/lsb-release ]; then
       # For some versions of Debian/Ubuntu without lsb_release command
+      # shellcheck source=/dev/null
       . /etc/lsb-release
       OS=$DISTRIB_ID
       VER=$DISTRIB_RELEASE

--- a/build/IPDK_Container/scripts/os_ver_details.sh
+++ b/build/IPDK_Container/scripts/os_ver_details.sh
@@ -27,20 +27,22 @@ get_os_ver_details()
   else
       # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
       OS=$(uname -s)
+      export OS
       VER=$(uname -r)
+      export VER
   fi
 }
 
 get_num_cores()
 {
-   nproc_exist=$(which nproc)
-   if [ ! -z "$nproc_exist" ];
+   nproc_exist=$(command -v nproc)
+   if [ -n "$nproc_exist" ];
    then
        NUM_CORES=$(nproc --all)
        echo "Num cores on a system: $NUM_CORES"
        if [ "$NUM_CORES" -gt 4 ]
        then
-           NUM_THREADS=$(($NUM_CORES / 4))
+           NUM_THREADS=$((NUM_CORES / 4))
            NUM_THREADS=-j$NUM_THREADS
        fi
 else

--- a/build/IPDK_Container/scripts/os_ver_details.sh
+++ b/build/IPDK_Container/scripts/os_ver_details.sh
@@ -46,8 +46,11 @@ get_num_cores()
        then
            NUM_THREADS=$((NUM_CORES / 4))
            NUM_THREADS=-j$NUM_THREADS
+       else
+           NUM_THREADS=${NUM_CORES}
        fi
-else
-    NUM_CORES=""
-fi
+    else
+        NUM_CORES=1
+        NUM_THREADS=1
+    fi
 }

--- a/build/IPDK_Container/scripts/run_ovs.sh
+++ b/build/IPDK_Container/scripts/run_ovs.sh
@@ -1,7 +1,7 @@
+#!/usr/bin/bash
 #Copyright (C) 2021 Intel Corporation
 #SPDX-License-Identifier: Apache-2.0
 
-#!/usr/bin/bash
 #set -o xtrace
 
 #Kill and delete any logs from previous run
@@ -10,12 +10,12 @@ echo "Killing OVS Processes If Already Running...."
 set +o errexit
 if [[ $(pidof ovsdb-server) ]]; then
         echo "Killing ovsdb-server process...."
-        kill -9 `pidof ovsdb-server`
+	kill -9 "$(pidof ovsdb-server)"
 fi
 
 if [[ $(pidof ovs-vswitchd) ]]; then
         echo "Killing ovs-vswitchd process...."
-        kill -9 `pidof ovs-vswitchd`
+	kill -9 "$(pidof ovs-vswitchd)"
 fi
 set -o errexit
 

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -1,7 +1,6 @@
+#!/usr/bin/bash
 #Copyright (C) 2021 Intel Corporation
 #SPDX-License-Identifier: Apache-2.0
-
-#!/usr/bin/bash
 
 #...Setting Hugepages...#
 mkdir /mnt/huge

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -10,10 +10,18 @@ echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
 echo "vm.nr_hugepages = 4096" >> /etc/sysctl.conf
 #sysctl -p /etc/sysctl.conf
 
-if [ ! -d /sys/devices/system/node/node0/hugepages-2048kB ] ; then
-	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
-else
+#
+# Check if the node version of hugepages exists, and set hugepages if so.
+#
+if [ -d /sys/devices/system/node/node0/hugepages-2048kB ] ; then
 	echo 1024 | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
 	echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+fi
+
+#
+# Check if the kernel/mm version of hugepages exists, and set hugepages if so.
+#
+if [ -d /sys/kernel/mm/hugepages/hugepages-2048kB ] ; then
+	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 fi
 

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -13,8 +13,10 @@ echo "vm.nr_hugepages = 4096" >> /etc/sysctl.conf
 #
 # Check if the node version of hugepages exists, and set hugepages if so.
 #
-if [ -d /sys/devices/system/node/node0/hugepages-2048kB ] ; then
+if [ -d /sys/devices/system/node/node0/hugepages/hugepages-2048kB ] ; then
 	echo 1024 | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+fi
+if [ -d /sys/devices/system/node/node1/hugepages/hugepages-2048kB ] ; then
 	echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
 fi
 
@@ -24,4 +26,3 @@ fi
 if [ -d /sys/kernel/mm/hugepages/hugepages-2048kB ] ; then
 	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
 fi
-

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -3,13 +3,17 @@
 #SPDX-License-Identifier: Apache-2.0
 
 #...Setting Hugepages...#
-mkdir /mnt/huge
+mkdir -p /mnt/huge
 mount -t hugetlbfs nodev /mnt/huge
 echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
 
 echo "vm.nr_hugepages = 4096" >> /etc/sysctl.conf
 #sysctl -p /etc/sysctl.conf
 
-echo 1024 | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
-echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+if [ ! -d /sys/devices/system/node/node0/hugepages-2048kB ] ; then
+	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+else
+	echo 1024 | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+	echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+fi
 

--- a/build/IPDK_Container/start_p4ovs.sh
+++ b/build/IPDK_Container/start_p4ovs.sh
@@ -18,6 +18,7 @@ SCRIPTS_DIR=/root/scripts
 export PATH="/root/scripts/:${PATH}"
 export PATH="$WORKDIR/P4-OVS/:${PATH}"
 
+# shellcheck source=scripts/os_ver_details.sh
 . ${SCRIPTS_DIR}/os_ver_details.sh
 get_os_ver_details
 
@@ -31,33 +32,33 @@ echo "SHELL_STRING=$SHELL_STRING"
 
 get_p4ovs_repo() {
     chmod +x ${SCRIPTS_DIR}/get_p4ovs_repo.sh && \
-        ${SHELL_STRING} ${SCRIPTS_DIR}/get_p4ovs_repo.sh $WORKDIR
+        ${SHELL_STRING} ${SCRIPTS_DIR}/get_p4ovs_repo.sh "$WORKDIR"
 }
 
 build_p4sde() {
     chmod +x ${SCRIPTS_DIR}/build_p4sde.sh && \
-        ${SHELL_STRING} ${SCRIPTS_DIR}/build_p4sde.sh $WORKDIR
+        ${SHELL_STRING} ${SCRIPTS_DIR}/build_p4sde.sh "$WORKDIR"
 }
 
 install_dependencies() {
     if [ "${OS}" = "Ubuntu" ]; then
-        cd $WORKDIR/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
+        cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
             sed -i s/v3.6.1/v3.7.1/g install_dep_packages.sh && \
             sed -i s/v1.17.2/v1.27.1/g install_dep_packages.sh && \
-            ./install_dep_packages.sh $WORKDIR
+            ./install_dep_packages.sh "$WORKDIR"
     else
-        cd $WORKDIR/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
-            ${SHELL_STRING} ./install_dep_packages.sh $WORKDIR
+        cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
+            ${SHELL_STRING} ./install_dep_packages.sh "$WORKDIR"
     fi
 }
 
 build_p4c () {
     chmod +x ${SCRIPTS_DIR}/build_p4c.sh && \
-        ${SHELL_STRING} ${SCRIPTS_DIR}/build_p4c.sh $WORKDIR
+        ${SHELL_STRING} ${SCRIPTS_DIR}/build_p4c.sh "$WORKDIR"
 }
 
 build_p4ovs () {
-   cd $WORKDIR/P4-OVS && ${SHELL_STRING} ./build-p4ovs.sh $WORKDIR/p4-sde/install
+   cd "$WORKDIR"/P4-OVS && ${SHELL_STRING} ./build-p4ovs.sh "$WORKDIR"/p4-sde/install
 }
 
 get_p4ovs_repo


### PR DESCRIPTION
This commit adds a "shellcheck" Makefile target, and fixes all of
the bash scripts to pass a shellcheck [1] run. Shellcheck does
static analysis of bash scripts. In the past, it's saved me hours
of debugging things in production, I find it useful to use early
in a projects lifetime. Once we have proper CI/CD for IPDK, we'd
want to run the "shellcheck" target on each pull request before
merging, for example.

[1] https://github.com/koalaman/shellcheck

Signed-off-by: Kyle Mestery <mestery@mestery.com>