### PR TITLE
IPDK: Optimize docker image

### DIFF
--- a/build/IPDK_Container/Dockerfile
+++ b/build/IPDK_Container/Dockerfile
@@ -11,32 +11,47 @@ ARG PROXY
 
 # Installing dependent packages required for DPDK Build
 RUN dnf -y update && \
-  dnf -y groupinstall "Development Tools" "Development Libraries" && \
-  dnf -y install meson && \
-  dnf -y install cmake && \
-  dnf -y install gdb && \
-  dnf -y install libtool && \
-  dnf -y install autoconf && \
-  dnf -y install autoconf-archive && \
-  dnf -y install automake && \
-  dnf -y install scapy && \
-  dnf -y install iproute && \
-  dnf -y install net-tools && \
-  dnf -y install gflags-devel && \
-  dnf -y install iputils && \
-  dnf -y install cctz && \
-  dnf -y install json-devel && \
-  dnf -y install python && \
-  dnf -y install grpc-plugins && \
-  dnf -y install python3-cffi && \
-  dnf -y install libedit-devel && \
-  dnf -y install expat-devel && \
-  dnf -y install pip && \
-  dnf -y install flex && \
-  dnf -y install bison && \
-  dnf -y install libgc-devel && \
-  dnf -y install vim && \
-  dnf -y clean all
+    dnf install -y git \
+    meson \
+    cmake \
+    libtool \
+    clang \
+    gcc \
+    g++ \
+    autoconf \
+    automake \
+    autoconf-archive \
+    libconfig \
+    libgc-devel \
+    unifdef \
+    libffi-devel \
+    boost-iostreams \
+    boost-graph \
+    llvm \
+    pkg-config \
+    flex flex-devel \
+    zlib-devel \
+    iproute \
+    net-tools \
+    iputils \
+    python \
+    pip \
+    bison \
+    python3-setuptools \
+    python3-pip \
+    python3-wheel \
+    python3-cffi \
+    libedit-devel \
+    gmp-devel \
+    expat-devel \
+    boost-devel \
+    google-perftools \
+    curl \
+    connect-proxy \
+    coreutils \
+    which && \
+    dnf -y clean all && \
+    rm -rf /var/cache/yum
 
 # Installing all PYTHON packages
 RUN python -m pip install --upgrade pip && \
@@ -44,7 +59,9 @@ RUN python -m pip install --upgrade pip && \
     python -m pip install ovspy && \
     python -m pip install protobuf && \
     python -m pip install p4runtime && \
-    pip3 install pyelftools
+    pip3 install pyelftools && \
+    pip3 install scapy && \
+    pip3 install six
 
 WORKDIR /root
 COPY ./scripts scripts
@@ -54,6 +71,8 @@ WORKDIR /root
 COPY ./examples /root/examples
 COPY ./start_p4ovs.sh /root/start_p4ovs.sh 
 COPY ./run_ovs_cmds /root/run_ovs_cmds
-RUN source /root/start_p4ovs.sh /root
+RUN  /root/start_p4ovs.sh /root && \
+     rm -rf /root/P4OVS_DEPS_SRC_CODE && \
+     cd /root/P4-OVS/ && make clean
 #ADD ./start_p4ovs.sh /root/start_p4ovs
 #ENTRYPOINT exec /root/start_p4ovs.sh /root

--- a/build/IPDK_Container/scripts/build_p4c.sh
+++ b/build/IPDK_Container/scripts/build_p4c.sh
@@ -33,9 +33,11 @@ git clone https://github.com/p4lang/p4c.git --recursive P4C
 cd P4C
 git checkout $P4C_SHA
 mkdir build && cd build
-cmake ..
+cmake -DENABLE_BMV2=OFF -DENABLE_EBPF=OFF -DENABLE_UBPF=OFF \
+      -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF -DENABLE_GTESTS=OFF ..
 make $NUM_THREADS
 make $NUM_THREADS install
+make clean
 ldconfig
 
 set +e

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -11,6 +11,13 @@ echo "vm.nr_hugepages = 4096" >> /etc/sysctl.conf
 #sysctl -p /etc/sysctl.conf
 
 #
+# Check if the kernel/mm version of hugepages exists, and set hugepages if so.
+#
+if [ -d /sys/kernel/mm/hugepages/hugepages-2048kB ] ; then
+	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+fi
+
+#
 # Check if the node version of hugepages exists, and set hugepages if so.
 #
 if [ -d /sys/devices/system/node/node0/hugepages/hugepages-2048kB ] ; then
@@ -20,9 +27,3 @@ if [ -d /sys/devices/system/node/node1/hugepages/hugepages-2048kB ] ; then
 	echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
 fi
 
-#
-# Check if the kernel/mm version of hugepages exists, and set hugepages if so.
-#
-if [ -d /sys/kernel/mm/hugepages/hugepages-2048kB ] ; then
-	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
-fi


### PR DESCRIPTION
Docker image is taking ~13GB as of today.
Below changes are made in this review which would reduce ~6.5GB.
a) Install only necessary packages when building a docker image.
b) Run start_p4ovs.sh script as part of docker build.
c) Remove source code of dependent packages which are installed as
   part of install_dep_packages.sh
d) Make clean once P4-OVS and P4C are build and installed. For now,
   source code is left intentionally as it would help in further
   code reference and developments for user.
   (subsequent commits will have this for p4-driver as well)
e) Changes are made in set_hugepages.sh, when we have more than one node
   and once hugepages value is set for both nodes, this value is being
   re-set once /sys/kernel/mm/hugepages/hugepages-2048kB is set to 1024.
   This will not have an effect when we have single node, but for dual
   node, this value is resetting previously set 1024 value for both nodes.

This is a very first level commit to reduce memory taken by docker image
after docker commit. These changes are targeted for Fedora as of now.

Change-type: ImplementationChange
Title: IPDK: Optimize docker image
Signed-off-by: n-sandeep <sandeep.nagapattinam@intel.com>