### PR TITLE
vagrant: Add Vagrant environment

### DIFF
--- a/build/IPDK_Container/README_HOST_INSTALL.md
+++ b/build/IPDK_Container/README_HOST_INSTALL.md
@@ -6,6 +6,11 @@ the OVS-P4 switch.
 
 ## Steps To Install
 
+Note this method is using Vagrant with Virtualbox. Make sure you have nested
+virtualization enabled on your guest VM. There are many articles published on
+how to do this, but [this](https://stackoverflow.com/questions/54251855/virtualbox-enable-nested-vtx-amd-v-greyed-out)
+one is quite useful.
+
 ### Bringup the Vagrant VM:
 ```
 $ cd vagrant

--- a/build/IPDK_Container/README_HOST_INSTALL.md
+++ b/build/IPDK_Container/README_HOST_INSTALL.md
@@ -1,0 +1,76 @@
+# Host Install
+
+This method is supportd for either installing and using IPDK in a VM or on a
+host natively. This is in support of being able to run containers attached to
+the OVS-P4 switch.
+
+## Steps To Install
+
+### Bringup the Vagrant VM:
+```
+$ cd vagrant
+$ vagrant up
+```
+
+###Login to the VM
+```
+$ vagrant ssh
+Welcome to Ubuntu 20.04 LTS (GNU/Linux 5.4.0-31-generic x86_64)
+
+                  ubuntu-20.04-amd64-docker (virtualbox)
+                 _____ _____ _____ _____ _____ _____ _____
+                |  |  |  _  |   __| __  |  _  |   | |_   _|
+                |  |  |     |  |  |    -|     | | | | | |
+                 \___/|__|__|_____|__|__|__|__|_|___| |_|
+                       Sat May 23 14:38:33 UTC 2020
+                            Box version: 0.1.1
+
+  System information as of Wed 22 Dec 2021 05:47:40 PM UTC
+
+  System load:  1.08               Processes:                141
+  Usage of /:   12.1% of 38.65GB   Users logged in:          0
+  Memory usage: 3%                 IPv4 address for docker0: 172.17.0.1
+  Swap usage:   0%                 IPv4 address for eth0:    10.0.2.15
+
+vagrant@ubuntu2004:~$
+```
+
+### Run the install script to install all dependencies and build components.
+
+*NOTE*: This takes a long time, You also need to run these as root.
+
+Without a proxy:
+
+```
+vagrant@ubuntu2004:~$ sudo su
+root@ubuntu2004:~# /git/ipdk/scripts/host_install.sh
+```
+
+If using a proxy:
+
+```
+vagrant@ubuntu2004:~$ sudo su -
+root@ubuntu2004:~# /git/ipdk/scripts/host_install.sh -p [proxy name]
+```
+
+Note: To skip installing and building dependencies in the future, add a `-s`
+flag tot he host_install.sh script.
+
+### Start P4-OVS.
+
+```
+root@ubuntu2004:~$ cd P4-OVS/
+root@ubuntu2004:~/P4-OVS# source /root/P4-OVS/p4ovs_env_setup.sh /root/p4-sde/install
+root@ubuntu2004:~/P4-OVS# /root/scripts/set_hugepages.sh
+root@ubuntu2004:~/P4-OVS# /root/scripts/run_ovs.sh
+```
+
+5. Verify OVS is running:
+
+```
+root@ubuntu2004:~/P4-OVS# ovs-vsctl show
+bc71e3b7-45a7-4bc8-9706-88dab5002526
+root@ubuntu2004:~/P4-OVS#
+```
+
+### Next steps: Create some containers, create some OVS ports, build some P4 pipelines.

--- a/build/IPDK_Container/README_HOST_INSTALL.md
+++ b/build/IPDK_Container/README_HOST_INSTALL.md
@@ -47,7 +47,7 @@ vagrant@ubuntu2004:~$
 Without a proxy:
 
 ```
-vagrant@ubuntu2004:~$ sudo su
+vagrant@ubuntu2004:~$ sudo su -
 root@ubuntu2004:~# /git/ipdk/scripts/host_install.sh
 ```
 
@@ -59,15 +59,12 @@ root@ubuntu2004:~# /git/ipdk/scripts/host_install.sh -p [proxy name]
 ```
 
 Note: To skip installing and building dependencies in the future, add a `-s`
-flag tot he host_install.sh script.
+flag to the host_install.sh script.
 
-### Start P4-OVS.
+### Run the rundemo.sh script
 
 ```
-root@ubuntu2004:~$ cd P4-OVS/
-root@ubuntu2004:~/P4-OVS# source /root/P4-OVS/p4ovs_env_setup.sh /root/p4-sde/install
-root@ubuntu2004:~/P4-OVS# /root/scripts/set_hugepages.sh
-root@ubuntu2004:~/P4-OVS# /root/scripts/run_ovs.sh
+root@ubuntu2004:~$ /git/ipdk/scripts/rundemo.sh
 ```
 
 5. Verify OVS is running:
@@ -96,7 +93,7 @@ vagrant@ubuntu2004:~$ telnet localhost 6552
 
 ### Verify guest is finished booting
 
-It may take 3-5 minutes for both guest VMs to finish booting. You can
+It may take 6-9 minutes for both guest VMs to finish booting. You can
 watch each VM boot over the serial console.
 
 ```

--- a/build/IPDK_Container/README_HOST_INSTALL.md
+++ b/build/IPDK_Container/README_HOST_INSTALL.md
@@ -73,4 +73,71 @@ bc71e3b7-45a7-4bc8-9706-88dab5002526
 root@ubuntu2004:~/P4-OVS#
 ```
 
-### Next steps: Create some containers, create some OVS ports, build some P4 pipelines.
+### Connect to the guest VMs serial consoles
+
+You will need two login windows, one for each VM:
+
+```
+$ vagrant ssh
+vagrant@ubuntu2004:~$ telnet localhost 6551
+```
+
+And in another window:
+
+```
+$ vagrant ssh
+vagrant@ubuntu2004:~$ telnet localhost 6552
+```
+
+### Verify guest is finished booting
+
+It may take 3-5 minutes for both guest VMs to finish booting. You can
+watch each VM boot over the serial console.
+
+```
+[  307.519991] cloud-init[1249]: Cloud-init v. 21.4-0ubuntu1~20.04.1 running 'modules:config' at Thu, 06 Jan 2022 15:27:13 +0000. Up 297.85 seconds.
+[  OK  ] Finished Apply the settings specified in cloud-config.
+         Starting Execute cloud user/final scripts...
+ci-info: no authorized SSH keys fingerprints found for user ubuntu.
+<14>Jan  6 15:27:31 cloud-init: #############################################################
+<14>Jan  6 15:27:31 cloud-init: -----BEGIN SSH HOST KEY FINGERPRINTS-----
+<14>Jan  6 15:27:31 cloud-init: 1024 SHA256:XtiIx3+4O9dXfAapcvgVy9bTY0AadTx67JgIirP8fDU root@vm1 (DSA)
+<14>Jan  6 15:27:31 cloud-init: 256 SHA256:8KKnft4X6/5ANZjy4c9Pf8nLPghM25r2h7KQCcmMWJQ root@vm1 (ECDSA)
+<14>Jan  6 15:27:31 cloud-init: 256 SHA256:BOyEUuM4iXqSIlaoCcp+wOsLB3w+ZBZLPxxNdEY7WkQ root@vm1 (ED25519)
+<14>Jan  6 15:27:32 cloud-init: 3072 SHA256:GYvOtfpGNz7ILw0XZPkKOVZZZ/rRmafsDE1vcq5vptA root@vm1 (RSA)
+<14>Jan  6 15:27:32 cloud-init: -----END SSH HOST KEY FINGERPRINTS-----
+<14>Jan  6 15:27:32 cloud-init: #############################################################
+-----BEGIN SSH HOST KEY KEYS-----
+ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHN14OCnYTeMh09qRzmWhtXsCgMOQu5S4WLksyBkQsNFil50MPdN8EoE0hh4dw70UzctiMXmQW/vStGeeyLv7OA= root@vm1
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHtOReNwl7HPAz5EUR/6mRdACoNszPBcSS9tCUeot7CE root@vm1
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC4yha3xcGv+ISubnNDJvnunNXR1RgG2wCUzBz8Cry7DABZ3ykBsAl86y7tmbKa8/OcOl/rwMEQw9UzNU4zFxbB+m8V7hyEcIqdIMrkjwWg2rLZP9LIN+ia7xIm0SjRjH7D4TuGdGp31
+-----END SSH HOST KEY KEYS-----
+[  317.197933] cloud-init[1278]: Cloud-init v. 21.4-0ubuntu1~20.04.1 running 'modules:final' at Thu, 06 Jan 2022 15:27:29 +0000. Up 313.74 seconds.
+[  317.254438] cloud-init[1278]: ci-info: no authorized SSH keys fingerprints found for user ubuntu.
+[  317.296920] cloud-init[1278]: Cloud-init v. 21.4-0ubuntu1~20.04.1 finished at Thu, 06 Jan 2022 15:27:32 +0000. Datasource DataSourceNoCloud [seed=/dev/vda][dsmode=net].  Up s
+[  OK  ] Finished Execute cloud user/final scripts.
+[  OK  ] Reached target Cloud-init target.
+```
+
+### Ping across VMs
+
+Once you reach the following, you can login as the user `ubuntu` with the
+defined password `IPDK`. Then you can ping from vm1 to vm2, and P4-OVS will
+be used for networking traffic:
+
+```
+$ vagrant ssh
+vagrant@ubuntu2004:~$ telnet localhost 6551
+ubuntu@vm1:~$ ping -c 5 2.2.2.2
+PING 2.2.2.2 (2.2.2.2) 56(84) bytes of data.
+64 bytes from 2.2.2.2: icmp_seq=1 ttl=64 time=0.317 ms
+64 bytes from 2.2.2.2: icmp_seq=2 ttl=64 time=0.309 ms
+64 bytes from 2.2.2.2: icmp_seq=3 ttl=64 time=0.779 ms
+64 bytes from 2.2.2.2: icmp_seq=4 ttl=64 time=0.317 ms
+64 bytes from 2.2.2.2: icmp_seq=5 ttl=64 time=0.310 ms
+
+--- 2.2.2.2 ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 4011ms
+rtt min/avg/max/mdev = 0.309/0.406/0.779/0.186 ms
+ubuntu@vm1:~$
+```

--- a/build/IPDK_Container/scripts/get-image.sh
+++ b/build/IPDK_Container/scripts/get-image.sh
@@ -11,7 +11,6 @@ Usage: ${0##*/} release
 
    release is like 'xenial' or 'artful'.
     - Downloads an image from cloud-image.ubuntu.com
-    - converts it to raw format (from qcow2)
 EOF
 }
 fail() { echo "$@" 1>&2; exit 1; }
@@ -31,22 +30,13 @@ case "$rel" in
     precise|trusty|xenial) ofname="$rel-server-cloudimg-amd64-disk1.img";;
 esac
 
-raw="${fname%.img}.raw"
 if [ ! -f "$fname" ]; then
     url="$burl/$rel/current/$ofname"
     echo "downloading $url to $fname"
     wget -nc "$url" -O "$fname.tmp" &&
         mv "$fname.tmp" "$fname" || exit
-    rm -f "$raw"
-fi
-if [ ! -f "$raw" ]; then
-    echo "converting $fname to raw in $raw"
-    qemu-img convert -O raw "$fname" "$raw.tmp" &&
-        mv "$raw.tmp" "$raw" || exit
-    rm -f "$fname"
 fi
 
 echo "dist: $ofname"
-echo "raw:  $raw"
 
 # vi: ts=4 expandtab

--- a/build/IPDK_Container/scripts/get-image.sh
+++ b/build/IPDK_Container/scripts/get-image.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# NOTE: Taken from this gist:
+#
+# https://gist.github.com/smoser/635897f845f7cb56c0a7ac3018a4f476
+#
+
+Usage() {
+    cat <<EOF
+Usage: ${0##*/} release
+
+   release is like 'xenial' or 'artful'.
+    - Downloads an image from cloud-image.ubuntu.com
+    - converts it to raw format (from qcow2)
+EOF
+}
+fail() { echo "$@" 1>&2; exit 1; }
+
+rel="$1"
+[ "$1" = "-h" ] || [ "$1" = "--help" ] && { Usage; exit 0; }
+[ -n "$rel" ] || { Usage 1>&2; fail "Must give release"; }
+
+#arch="amd64"
+burl="${_PROTO:-https}://cloud-images.ubuntu.com/daily/server"
+fname=$rel-server-cloudimg-amd64.img
+ofname="$fname"
+
+# trusty and xenial have a '-disk1.img' while
+# other releases have just 'disk.img'
+case "$rel" in
+    precise|trusty|xenial) ofname="$rel-server-cloudimg-amd64-disk1.img";;
+esac
+
+raw="${fname%.img}.raw"
+if [ ! -f "$fname" ]; then
+    url="$burl/$rel/current/$ofname"
+    echo "downloading $url to $fname"
+    wget -nc "$url" -O "$fname.tmp" &&
+        mv "$fname.tmp" "$fname" || exit
+    rm -f "$raw"
+fi
+if [ ! -f "$raw" ]; then
+    echo "converting $fname to raw in $raw"
+    qemu-img convert -O raw "$fname" "$raw.tmp" &&
+        mv "$raw.tmp" "$raw" || exit
+    rm -f "$fname"
+fi
+
+echo "dist: $ofname"
+echo "raw:  $raw"
+
+# vi: ts=4 expandtab

--- a/build/IPDK_Container/scripts/host_install.sh
+++ b/build/IPDK_Container/scripts/host_install.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#Copyright (C) 2021 Intel Corporation
+#SPDX-License-Identifier: Apache-2.0
+#
+# Version 0.1.0
+
+# shellcheck source=scripts/os_ver_details.sh
+source os_ver_details.sh
+get_os_ver_details
+
+usage() {
+    echo ""
+    echo "Usage:"
+    echo "host_install.sh: -s -p"
+    echo ""
+    echo "  -p: Proxy to use"
+    echo "  -s: Skip installing and building dependencies"
+    echo ""
+}
+
+INSTALL_DEPENDENCIES=y
+
+# Process commandline arguments
+while getopts sp: flag
+do
+    case "${flag}" in
+        p) 
+            http_proxy="${OPTARG}"
+            https_proxy="${OPTARG}"
+            export http_proxy
+            export https_proxy
+            ;;
+        s)
+            INSTALL_DEPENDENCIES=n
+            ;;
+        *)
+            usage
+            exit
+            ;;
+    esac
+done
+
+export INSTALL_DEPENDENCIES
+
+if [ "${OS}" = "Ubuntu" ]
+then
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+    apt-get update
+
+    apt-get install -y apt-utils \
+        git \
+        meson \
+        cmake \
+        libtool \
+        clang \
+        gcc \
+        g++ \
+        autoconf \
+        automake \
+        autoconf-archive \
+        libconfig++-dev \
+        libgc-dev \
+        unifdef \
+        libffi-dev \
+        libboost-iostreams-dev \
+        libboost-graph-dev \
+        llvm \
+        pkg-config \
+        flex libfl-dev \
+        zlib1g-dev \
+        iproute2 \
+        net-tools \
+        iputils-arping \
+        iputils-ping \
+        iputils-tracepath \
+        python \
+        pip \
+        bison \
+        python3-setuptools \
+        python3-pip \
+        python3-wheel \
+        python3-cffi \
+        libedit-dev \
+        libgmp-dev \
+        libexpat1-dev \
+        libboost-dev \
+        google-perftools \
+        curl \
+        connect-proxy \
+        coreutils \
+        sudo \
+        make
+
+        pip install --upgrade pip && \
+        pip install grpcio \
+            ovspy \
+            protobuf \
+            p4runtime \
+            pyelftools \
+            scapy \
+            six
+else
+    dnf -y update && \
+    dnf install -y git \
+    meson \
+    cmake \
+    libtool \
+    clang \
+    gcc \
+    g++ \
+    autoconf \
+    automake \
+    autoconf-archive \
+    libconfig \
+    libgc-devel \
+    unifdef \
+    libffi-devel \
+    boost-iostreams \
+    boost-graph \
+    llvm \
+    pkg-config \
+    flex flex-devel \
+    zlib-devel \
+    iproute \
+    net-tools \
+    iputils \
+    python \
+    pip \
+    bison \
+    python3-setuptools \
+    python3-pip \
+    python3-wheel \
+    python3-cffi \
+    libedit-devel \
+    gmp-devel \
+    expat-devel \
+    boost-devel \
+    google-perftools \
+    curl \
+    connect-proxy \
+    coreutils \
+    which
+
+    # Installing all PYTHON packages
+    python -m pip install --upgrade pip && \
+    python -m pip install grpcio && \
+    python -m pip install ovspy && \
+    python -m pip install protobuf && \
+    python -m pip install p4runtime && \
+    pip3 install pyelftools && \
+    pip3 install scapy && \
+    pip3 install six
+fi
+
+cd /root || exit
+cp -r /git/ipdk/scripts scripts
+cp -r /git/ipdk/examples examples
+cp /git/ipdk/start_p4ovs.sh start_p4ovs.sh
+cp /git/ipdk/run_ovs_cmds run_ovs_cmds
+
+export OS_VERSION=20.04
+export IMAGE_NAME=ipdk/p4-ovs-ubuntu20.04
+export REPO=${PWD}
+TAG="$(cd "${REPO}" && git rev-parse --short HEAD)"
+export TAG
+
+echo "$OS_VERSION"
+echo "$IMAGE_NAME"
+echo "$REPO"
+echo "$TAG"
+
+/root/start_p4ovs.sh /root && \
+    rm -rf /root/P4OVS_DEPS_SRC_CODE && \
+    cd /root/P4-OVS/ && make clean

--- a/build/IPDK_Container/scripts/run_cleanup.sh
+++ b/build/IPDK_Container/scripts/run_cleanup.sh
@@ -43,5 +43,5 @@ elif [ "${KEEP_SOURCE_CODE,,}" = "${FLAG_YES,,}" ]; then
 
 else
     echo "Unrecognized option for source code retention/removal: " \
-        ${KEEP_SOURCE_CODE}
+        "${KEEP_SOURCE_CODE}"
 fi

--- a/build/IPDK_Container/scripts/rundemo.sh
+++ b/build/IPDK_Container/scripts/rundemo.sh
@@ -117,6 +117,7 @@ pushd /root/P4-OVS || exit
 # shellcheck source=/dev/null
 source /root/P4-OVS/p4ovs_env_setup.sh /root/p4-sde/install
 /root/scripts/set_hugepages.sh
+sysctl -w vm.nr_hugepages=8400
 /root/scripts/run_ovs.sh
 popd || exit
 

--- a/build/IPDK_Container/scripts/rundemo.sh
+++ b/build/IPDK_Container/scripts/rundemo.sh
@@ -2,6 +2,21 @@
 #Copyright (C) 2021 Intel Corporation
 #SPDX-License-Identifier: Apache-2.0
 
+stty -echoctl # hide ctrl-c
+
+# Exit function
+exit_function()
+{
+    echo "Exiting cleanly"
+    pushd /root || exit
+    rm -f network-config-v1.yaml meta-data user-data
+    rm -rf /tmp/vhost-user-*
+    rm -f vm1.qcow2 vm2.qcow2
+    popd || exit
+}
+
+trap 'exit_function' SIGINT
+
 echo ""
 echo "Cleaning from previous run"
 echo ""
@@ -107,7 +122,7 @@ EOF
 cloud-localds -v --network-config=network-config-v1.yaml \
     seed2.img user-data meta-data
 
-#rm -f network-config-v1.yaml meta-data user-data
+rm -f network-config-v1.yaml meta-data user-data
 
 echo ""
 echo "Setting hugepages up and starting P4-OVS"

--- a/build/IPDK_Container/scripts/rundemo.sh
+++ b/build/IPDK_Container/scripts/rundemo.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+#Copyright (C) 2021 Intel Corporation
+#SPDX-License-Identifier: Apache-2.0
+
+echo ""
+echo "Cleaning from previous run"
+echo ""
+
+rm -rf /tmp/vhost-user-*
+killall ovsdb-server
+killall ovs-vswitchd
+
+#echo ""
+#echo "Pulling down cirros image and configuring"
+#echo ""
+#
+#pushd /root || exit
+#wget -nc http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
+#cp cirros-0.5.2-x86_64-disk.img vm1.qcow2
+#cp cirros-0.5.2-x86_64-disk.img vm2.qcow2
+#popd || exit
+
+echo ""
+echo "Creating Ubuntu focal image"
+echo ""
+
+pushd /root || exit
+/git/ipdk/scripts/get-image.sh focal
+qemu-img create -f qcow2 -b focal-server-cloudimg-amd64.raw disk.img
+rm -f vm1.qcow2 vm2.qcow2
+cp disk.img vm1.qcow2
+cp disk.img vm2.qcow2
+popd || exit
+
+
+echo ""
+echo "Configuring VM networking and creating cloud-init images"
+echo ""
+
+cat << EOF >> network-config-v1.yaml
+version: 1
+config:
+  - type: physical
+    name: interface0
+    mac_address: "52:54:00:34:12:aa"
+    subnets:
+      - type: static
+        address: 1.1.1.1
+        netmask: 255.255.255.0
+        gateway: 1.1.1.254
+  - type: route
+    destination: 2.2.2.0/24
+    gateway: 1.1.1.1
+EOF
+
+cat << EOF >> meta-data
+instance-id: 506f2788-9741-4ed8-af53-c6a21383d09a
+local-hostname: vm1
+EOF
+
+cat << EOF >> user-data
+#cloud-config
+password: IPDK
+chpasswd: { expire: False }
+ssh_pwauth: True
+runcmd:
+  - [ sudo, ip, route, add, "2.2.2.0/24", via, "1.1.1.1", dev, interface0 ]
+  - [ sudo, ip, neigh, add, dev, interface0, '2.2.2.2', lladdr, '52:54:00:34:12:bb' ]
+EOF
+
+cloud-localds -v --network-config=network-config-v1.yaml \
+    seed1.img user-data meta-data
+
+rm -f network-config-v1.yaml meta-data user-data
+
+cat << EOF >> network-config-v1.yaml
+version: 1
+config:
+  - type: physical
+    name: interface0
+    mac_address: "52:54:00:34:12:bb"
+    subnets:
+      - type: static
+        address: 2.2.2.2
+        netmask: 255.255.255.0
+        gateway: 2.2.2.254
+  - type: route
+    destination: 1.1.1.0/24
+    gateway: 2.2.2.2
+EOF
+
+cat << EOF >> meta-data
+instance-id: 606f2788-9741-4ed8-af53-c6a21383d09b
+local-hostname: vm2
+EOF
+
+cat << EOF >> user-data
+#cloud-config
+password: IPDK
+chpasswd: { expire: False }
+ssh_pwauth: True
+runcmd:
+  - [ sudo, ip, route, add, "1.1.1.0/24", via, "2.2.2.2", dev, interface0 ]
+  - [ sudo, ip, neigh, add, dev, interface0, '1.1.1.1', lladdr, '52:54:00:34:12:aa' ]
+EOF
+
+cloud-localds -v --network-config=network-config-v1.yaml \
+    seed2.img user-data meta-data
+
+#rm -f network-config-v1.yaml meta-data user-data
+
+echo ""
+echo "Setting hugepages up and starting P4-OVS"
+echo ""
+
+pushd /root/P4-OVS || exit
+# shellcheck source=/dev/null
+source /root/P4-OVS/p4ovs_env_setup.sh /root/p4-sde/install
+/root/scripts/set_hugepages.sh
+/root/scripts/run_ovs.sh
+popd || exit
+
+echo ""
+echo "Creating ovs-p4 switch"
+echo ""
+
+ovs-vsctl add-br ovs-p4
+
+echo ""
+echo "Creating vhost-user ports"
+echo ""
+
+pushd /root/P4-OVS || exit
+# shellcheck source=/dev/null
+source /root/P4-OVS/p4ovs_env_setup.sh /root/p4-sde/install
+gnmi-cli set "device:virtual-device,name:net_vhost0,host:host1,\
+    device-type:VIRTIO_NET,queues:1,socket-path:/tmp/vhost-user-0,\
+    port-type:LINK"
+gnmi-cli set "device:virtual-device,name:net_vhost1,host:host2,\
+    device-type:VIRTIO_NET,queues:1,socket-path:/tmp/vhost-user-1,\
+    port-type:LINK"
+popd || exit
+
+echo ""
+echo "Generating dependent files from P4C and OVS pipeline builder"
+echo ""
+
+export OUTPUT_DIR=/root/examples/simple_l3/
+p4c --arch psa --target dpdk --output $OUTPUT_DIR/pipe --p4runtime-files \
+    $OUTPUT_DIR/p4Info.txt --bf-rt-schema $OUTPUT_DIR/bf-rt.json \
+    --context $OUTPUT_DIR/pipe/context.json $OUTPUT_DIR/simple_l3.p4
+pushd /root/examples/simple_l3/ || exit
+ovs_pipeline_builder --p4c_conf_file=simple_l3.conf \
+    --bf_pipeline_config_binary_file=simple_l3.pb.bin
+popd || exit
+
+echo ""
+echo "Starting VM1_TAP_DEV"
+echo ""
+
+    #-object memory-backend-file,id=mem,size=1024M,mem-path=/hugetlbfs1,share=on \
+kvm -smp 1 -m 256M \
+    -boot c -cpu host --enable-kvm -nographic \
+    -name VM1_TAP_DEV \
+    -hda ./vm1.qcow2 \
+    -drive file=seed1.img,id=seed,if=none,format=raw,index=1 \
+    -device virtio-blk,drive=seed \
+    -object memory-backend-file,id=mem,size=256M,mem-path=/mnt/huge,share=on \
+    -numa node,memdev=mem \
+    -mem-prealloc \
+    -chardev socket,id=char1,path=/tmp/vhost-user-0 \
+    -netdev type=vhost-user,id=netdev0,chardev=char1,vhostforce \
+    -device virtio-net-pci,mac=52:54:00:34:12:aa,netdev=netdev0 \
+    -serial telnet::6551,server,nowait &
+
+sleep 5
+echo ""
+echo "Waiting 10 seconds before starting second VM"
+echo ""
+for i in {1..10}
+do
+    sleep 1
+    echo -n "."
+    if [ "$(( i % 30 ))" == "0" ]
+    then
+        echo ""
+    fi
+done
+echo ""
+echo "Starting VM2_TAP_DEV"
+echo ""
+
+kvm -smp 1 -m 256M \
+    -boot c -cpu host --enable-kvm -nographic \
+    -name VM2_TAP_DEV \
+    -hda ./vm2.qcow2 \
+    -drive file=seed2.img,id=seed,if=none,format=raw,index=1 \
+    -device virtio-blk,drive=seed \
+    -object memory-backend-file,id=mem,size=256M,mem-path=/mnt/huge,share=on \
+    -numa node,memdev=mem \
+    -mem-prealloc \
+    -chardev socket,id=char2,path=/tmp/vhost-user-1 \
+    -netdev type=vhost-user,id=netdev1,chardev=char2,vhostforce \
+    -device virtio-net-pci,mac=52:54:00:34:12:bb,netdev=netdev1 \
+    -serial telnet::6552,server,nowait &
+
+echo ""
+echo "Programming P4-OVS pipelines"
+echo ""
+
+ovs-p4ctl set-pipe br0 /root/examples/simple_l3/simple_l3.pb.bin \
+    /root/examples/simple_l3/p4Info.txt
+ovs-p4ctl add-entry br0 ingress.ipv4_host \
+    "hdr.ipv4.dst_addr=1.1.1.1,action=ingress.send(0)"
+ovs-p4ctl add-entry br0 ingress.ipv4_host \
+    "hdr.ipv4.dst_addr=2.2.2.2,action=ingress.send(1)"

--- a/build/IPDK_Container/scripts/rundemo.sh
+++ b/build/IPDK_Container/scripts/rundemo.sh
@@ -13,6 +13,7 @@ exit_function()
     rm -rf /tmp/vhost-user-*
     rm -f vm1.qcow2 vm2.qcow2
     popd || exit
+    exit
 }
 
 trap 'exit_function' SIGINT
@@ -25,26 +26,15 @@ rm -rf /tmp/vhost-user-*
 killall ovsdb-server
 killall ovs-vswitchd
 
-#echo ""
-#echo "Pulling down cirros image and configuring"
-#echo ""
-#
-#pushd /root || exit
-#wget -nc http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
-#cp cirros-0.5.2-x86_64-disk.img vm1.qcow2
-#cp cirros-0.5.2-x86_64-disk.img vm2.qcow2
-#popd || exit
-
 echo ""
 echo "Creating Ubuntu focal image"
 echo ""
 
 pushd /root || exit
 /git/ipdk/scripts/get-image.sh focal
-qemu-img create -f qcow2 -b focal-server-cloudimg-amd64.raw disk.img
 rm -f vm1.qcow2 vm2.qcow2
-cp disk.img vm1.qcow2
-cp disk.img vm2.qcow2
+cp focal-server-cloudimg-amd64.img vm1.qcow2
+cp focal-server-cloudimg-amd64.img vm2.qcow2
 popd || exit
 
 
@@ -132,15 +122,8 @@ pushd /root/P4-OVS || exit
 # shellcheck source=/dev/null
 source /root/P4-OVS/p4ovs_env_setup.sh /root/p4-sde/install
 /root/scripts/set_hugepages.sh
-sysctl -w vm.nr_hugepages=8400
 /root/scripts/run_ovs.sh
 popd || exit
-
-echo ""
-echo "Creating ovs-p4 switch"
-echo ""
-
-ovs-vsctl add-br ovs-p4
 
 echo ""
 echo "Creating vhost-user ports"

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -4,8 +4,14 @@
 
 #...Setting Hugepages...#
 mkdir -p /mnt/huge
-mount -t hugetlbfs nodev /mnt/huge
-echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
+if [ "$(mount | grep hugetlbfs)" == "" ]
+then
+	mount -t hugetlbfs nodev /mnt/huge
+fi
+if [ "$(grep huge < /etc/fstab)" == "" ]
+then
+	echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
+fi
 
 echo "vm.nr_hugepages = 4096" >> /etc/sysctl.conf
 #sysctl -p /etc/sysctl.conf

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -13,8 +13,11 @@ then
 	echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
 fi
 
-echo "vm.nr_hugepages = 4096" >> /etc/sysctl.conf
-#sysctl -p /etc/sysctl.conf
+if [ "$(grep nr_hugepages < /etc/sysctl.conf)" == "" ]
+then
+	echo "vm.nr_hugepages = 1024" >> /etc/sysctl.conf
+	#sysctl -p /etc/sysctl.conf
+fi
 
 #
 # Check if the kernel/mm version of hugepages exists, and set hugepages if so.

--- a/build/IPDK_Container/start_p4ovs.sh
+++ b/build/IPDK_Container/start_p4ovs.sh
@@ -61,8 +61,11 @@ build_p4ovs () {
    cd "$WORKDIR"/P4-OVS && ${SHELL_STRING} ./build-p4ovs.sh "$WORKDIR"/p4-sde/install
 }
 
-get_p4ovs_repo
-build_p4sde
-install_dependencies
-build_p4c
+if [ -z "${INSTALL_DEPENDENCIES}" ] || [ "${INSTALL_DEPENDENCIES}" == "y" ]
+then
+    get_p4ovs_repo
+    build_p4sde
+    install_dependencies
+    build_p4c
+fi
 build_p4ovs

--- a/build/IPDK_Container/vagrant/.gitignore
+++ b/build/IPDK_Container/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/build/IPDK_Container/vagrant/Vagrantfile
+++ b/build/IPDK_Container/vagrant/Vagrantfile
@@ -1,0 +1,19 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "kwilczynski/ubuntu-20.04-docker"
+
+  config.vm.provider "virtualbox" do |v|
+    v.name = "ipdk-ubuntu"
+    v.memory = 8192
+    v.cpus = 4
+    v.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
+  end
+
+  config.vm.synced_folder "..", "/git/ipdk"
+
+  # NOTE: Configure any proxy below.
+  #config.proxy.http     = "http://proxy:911"
+  #config.proxy.https    = "http://proxy:911"
+  #config.proxy.no_proxy = "no_proxy=noproxy.com,.10.0.0.0/8,192.168.0.0/16,localhost,.local,127.0.0.0/8"
+
+  config.vm.provision "shell", path: "provision.sh"
+end

--- a/build/IPDK_Container/vagrant/provision.sh
+++ b/build/IPDK_Container/vagrant/provision.sh
@@ -50,7 +50,9 @@ apt-get install -y apt-utils \
         connect-proxy \
         coreutils \
         sudo \
-        make
+        make \
+        cloud-image-utils \
+        telnet
 
 pip install --upgrade pip
 pip install grpcio \

--- a/build/IPDK_Container/vagrant/provision.sh
+++ b/build/IPDK_Container/vagrant/provision.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#Copyright (C) 2021 Intel Corporation
+#SPDX-License-Identifier: Apache-2.0
+#
+# Version 0.1.0
+
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+apt-get update
+
+apt-get install -y apt-utils \
+        git \
+        meson \
+        cmake \
+        libtool \
+        clang \
+        gcc \
+        g++ \
+        autoconf \
+        automake \
+        autoconf-archive \
+        libconfig++-dev \
+        libgc-dev \
+        unifdef \
+        libffi-dev \
+        libboost-iostreams-dev \
+        libboost-graph-dev \
+        llvm \
+        pkg-config \
+        flex libfl-dev \
+        zlib1g-dev \
+        iproute2 \
+        net-tools \
+        iputils-arping \
+        iputils-ping \
+        iputils-tracepath \
+        python \
+        pip \
+        bison \
+        python3-setuptools \
+        python3-pip \
+        python3-wheel \
+        python3-cffi \
+        libedit-dev \
+        libgmp-dev \
+        libexpat1-dev \
+        libboost-dev \
+        google-perftools \
+        curl \
+        connect-proxy \
+        coreutils \
+        sudo \
+        make
+
+pip install --upgrade pip
+pip install grpcio \
+            ovspy \
+            protobuf \
+            p4runtime \
+            pyelftools \
+            scapy \
+            six


### PR DESCRIPTION
Add a Vagrant environment, which makes testing a bit easier. Instructions are added on how to use the environment.

Note, I had to modify a few scripts to allow for integration with the Vagrant environment.

Closes Issue #36

Signed-off-by: Kyle Mestery <mestery@mestery.com>