### PR TITLE
IPDK: Enable make clean for p4-driver repository

### DIFF
--- a/build/IPDK_Container/README
+++ b/build/IPDK_Container/README
@@ -57,6 +57,11 @@ Commands to bring-up container and run OvS with P4:
 2) i) Run - 'make build-nc' - To build a docker image while no proxy.
    ii) Run - 'make build-nc-proxy' - To build a docker image while running
        behind proxy.
+   iii) Run - 'make build' - To build a docker image while no proxy,
+        with cached previous build's data.
+   iv) Run - 'make build-proxy' - To build a docker image while running
+       behind proxy, with cached previous build's data.
+
 3) Run - 'make volume' - To create a shared volume and configure your IPDK
 container to use it. This shares '/tmp' directory in your container with 
 Mountpoint directory of the docker shared volume. 'docker volume inspect shared'
@@ -133,7 +138,7 @@ VM2:
 ----
 qemu-kvm -smp 4 -m 1024M \
     -boot c -cpu host -enable-kvm -nographic \
-    -L /root/pc-bios -name VM1_TAP_DEV \
+    -L /root/pc-bios -name VM2_TAP_DEV \
     -hda ./vm2.qcow2 \
     -object memory-backend-file,id=mem,size=1024M,mem-path=/dev/hugepages,share=on \
     -mem-prealloc \

--- a/build/IPDK_Container/scripts/run_cleanup.sh
+++ b/build/IPDK_Container/scripts/run_cleanup.sh
@@ -35,9 +35,8 @@ elif [ "${KEEP_SOURCE_CODE,,}" = "${FLAG_YES,,}" ]; then
     echo "Make clean P4-OVS"
     cd "${ROOT_DIR}/P4-OVS" && make clean
 
-    # TODO
-    # echo "Make clean p4-driver"
-    # cd "${ROOT_DIR}/p4-sde/p4-driver" && make clean
+    echo "Make clean p4-driver"
+    cd "${ROOT_DIR}/p4-sde/p4-driver" && make clean
 
     echo "Make clean P4C"
     cd "${ROOT_DIR}/P4C/build" && make clean

--- a/build/IPDK_Container/scripts/set_hugepages.sh
+++ b/build/IPDK_Container/scripts/set_hugepages.sh
@@ -26,4 +26,3 @@ fi
 if [ -d /sys/devices/system/node/node1/hugepages/hugepages-2048kB ] ; then
 	echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
 fi
-


### PR DESCRIPTION
- Review is raised to enable "make clean" option in p4-driver
repository to reduce memory when KEEP_SOURCE_CODE flag is YES
- Update README with some more context

Change-type: Other
Title: IPDK: Enable make clean for p4-driver repository
Signed-off-by: n-sandeep <sandeep.nagapattinam@intel.com>