### PR TITLE
build_p4c.sh: Enable eBPF p4c backend

### DIFF
--- a/build/IPDK_Container/scripts/build_p4c.sh
+++ b/build/IPDK_Container/scripts/build_p4c.sh
@@ -33,8 +33,8 @@ git clone https://github.com/p4lang/p4c.git --recursive P4C
 cd P4C
 git checkout $P4C_SHA
 mkdir build && cd build
-cmake -DENABLE_BMV2=OFF -DENABLE_EBPF=ON -DENABLE_UBPF=OFF \
-      -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF -DENABLE_GTESTS=OFF ..
+cmake -DENABLE_BMV2=OFF \ -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF \
+      -DENABLE_GTESTS=OFF ..
 make $NUM_THREADS
 make $NUM_THREADS install
 make $NUM_THREADS clean

--- a/build/IPDK_Container/scripts/build_p4c.sh
+++ b/build/IPDK_Container/scripts/build_p4c.sh
@@ -33,7 +33,7 @@ git clone https://github.com/p4lang/p4c.git --recursive P4C
 cd P4C
 git checkout $P4C_SHA
 mkdir build && cd build
-cmake -DENABLE_BMV2=OFF -DENABLE_EBPF=OFF -DENABLE_UBPF=OFF \
+cmake -DENABLE_BMV2=OFF -DENABLE_EBPF=ON -DENABLE_UBPF=OFF \
       -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF -DENABLE_GTESTS=OFF ..
 make $NUM_THREADS
 make $NUM_THREADS install


### PR DESCRIPTION
This enables the building of the eBPF backend when building p4c.

Signed-off-by: Kyle Mestery <mestery@mestery.com>