### PR TITLE
host_install.sh: Source os_ver_details.sh

### DIFF
--- a/build/IPDK_Container/README_HOST_INSTALL.md
+++ b/build/IPDK_Container/README_HOST_INSTALL.md
@@ -48,7 +48,7 @@ Without a proxy:
 
 ```
 vagrant@ubuntu2004:~$ sudo su -
-root@ubuntu2004:~# /git/ipdk/scripts/host_install.sh
+root@ubuntu2004:~# SCRIPT_DIR=/git/ipdk/scripts /git/ipdk/scripts/host_install.sh
 ```
 
 If using a proxy:

--- a/build/IPDK_Container/scripts/host_install.sh
+++ b/build/IPDK_Container/scripts/host_install.sh
@@ -5,7 +5,7 @@
 # Version 0.1.0
 
 # shellcheck source=scripts/os_ver_details.sh
-source os_ver_details.sh
+source "${SCRIPT_DIR}/os_ver_details.sh"
 get_os_ver_details
 
 usage() {


### PR DESCRIPTION
This fixes the errors identified in #58 where the top-level sourcing of
the file `os_ver_details.sh` wasn't being done with a full path. I also
updated the instructions in README_HOST_INSTALL.sh to address the
example in there.

Closes #58

Signed-off-by: Kyle Mestery <mestery@mestery.com>