### PR TITLE
docs: Correct proxy usage of host_install.sh

### DIFF
--- a/build/README_NATIVE.md
+++ b/build/README_NATIVE.md
@@ -56,7 +56,7 @@ If using a proxy:
 
 ```
 vagrant@ubuntu2004:~$ sudo su -
-root@ubuntu2004:~# /git/ipdk/build/scripts/host_install.sh -p [proxy name]
+root@ubuntu2004:~# SCRIPT_DIR=/git/ipdk/build/scripts /git/ipdk/build/scripts/host_install.sh -p [proxy name]
 ```
 
 Note: To skip installing and building dependencies in the future, add a `-s`


### PR DESCRIPTION
When #60 was merged, I forgot to update the proxy usage of
host_install.sh to match the non-proxy use case. This corrects that
mistake.

Closes #65

Signed-off-by: Kyle Mestery <mestery@mestery.com>