### PR TITLE
p4c-xdp: Build and install p4c-xdp compiler

### DIFF
--- a/build/scripts/build_p4c.sh
+++ b/build/scripts/build_p4c.sh
@@ -40,6 +40,14 @@ git checkout $P4C_SHA
 #this change
 #TODO: See if this patch can be upstreamed to p4lang
 git apply $PATCH_DIR/PATCH-01-P4C
+mkdir extensions
+pushd extensions || exit
+git clone https://github.com/vmware/p4c-xdp.git
+ln -s ~/P4C p4c-xdp/p4c
+popd
+pushd backends/ebpf || exit
+"$WORKDIR"/P4C/backends/ebpf/build_libbpf
+popd
 mkdir build && cd build
 cmake -DENABLE_BMV2=OFF \ -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF \
       -DENABLE_GTESTS=OFF ..

--- a/build/vagrant-container/provision.sh
+++ b/build/vagrant-container/provision.sh
@@ -53,7 +53,8 @@ apt-get install -y apt-utils \
         make \
         cloud-image-utils \
         telnet \
-        qemu-kvm
+        qemu-kvm \
+        libelf-dev
 
 pip install --upgrade pip
 pip install grpcio \

--- a/build/vagrant-native/provision.sh
+++ b/build/vagrant-native/provision.sh
@@ -53,7 +53,8 @@ apt-get install -y apt-utils \
         make \
         cloud-image-utils \
         telnet \
-        qemu-kvm
+        qemu-kvm \
+        libelf-dev
 
 pip install --upgrade pip
 pip install grpcio \


### PR DESCRIPTION
This loads the p4c-xdp compiler extension, builds it, and instals it as
a part of the host native install. Useful for experimenting with P4 to
XDP.

Signed-off-by: Kyle Mestery <mestery@mestery.com>