### PR TITLE
Add ibprotobuf-dev and protobuf-compiler to apt-get list

### DIFF
--- a/build/Dockerfile.ubuntu
+++ b/build/Dockerfile.ubuntu
@@ -51,6 +51,8 @@ RUN apt-get install -y apt-utils \
     libgmp-dev \
     libexpat1-dev \
     libboost-dev \
+    ibprotobuf-dev \
+    protobuf-compiler \
     google-perftools \
     curl \
     connect-proxy \


### PR DESCRIPTION
Fixes https://github.com/ipdk-io/ipdk/issues/74