### PR TITLE
Implement ipdk install [environment] option

### DIFF
--- a/build/README_DOCKER.md
+++ b/build/README_DOCKER.md
@@ -69,6 +69,11 @@ execute the given `export PATH=<>` command to add the `ipdk` command
 to your current environment path each time you open a new terminal to your
 system!
 
+The IPDK CLI is by default setup for a `Fedora:33` environment. Build
+and run your IPDK container with the `ubuntu:20.04` or `ubuntu:18.04` base
+environment by running `ipdk install ubuntu2004` or `ipdk install ubuntu1804`.
+`ipdk install default` will bring you back to the default environment (fedora)
+
 ## Section 1: Bring-up IPDK Container
 
 ### Pre-requisites to run IPDK container
@@ -98,11 +103,6 @@ configuration file settings and inner workings!
 - By default source code for P4-OVS, p4-driver and P4C will not be retained in
   the IPDK container when build. If user wants to retain source code, set the
   (`KEEP_SOURCE_CODE=true`) option in the CLI configuration file.
-- The IPDK container is by default build with a `Fedora:33` base image. Build
-  and run your IPDK container with the Ubuntu20.04 base image by setting
-  `BASE_IMG=ubuntu:20.04`, `IMAGE_NAME=ipdk/p4-ovs-ubuntu20.04` and
-  `DOCKERFILE=${SCRIPT_DIR}/../Dockerfile.ubuntu` in your user CLI configuration
-  file.
 - Set the location of the working directory for the logs, interfaces and
   example VM images by setting the `VOLUME=` option in your user CLI
   configuration file. Default location is `~/.ipdk/volume`
@@ -320,7 +320,7 @@ the host in `~/.ipdk/examples`, by executing:
     ipdk [options] examples
 ```
 
-# Section 4: Inner workings
+# Section 4: IPDK CLI inner workings
 
 TODO: Add all specific things about how the IPDK container and cli works.
 

--- a/build/scripts/ipdk-lib.sh
+++ b/build/scripts/ipdk-lib.sh
@@ -13,6 +13,42 @@ print_banner() {
 	echo ""
 }
 
+#
+# Replace configuration line with new line and if not exist add
+# $1 = SEARCH_FOR
+# $2 = NEW_LINE
+# $3 = FILE - filepath to replace/add line in/to
+#
+change_config_line() {
+	local SEARCH_FOR=$1; shift
+	local NEW_LINE=$1; shift
+	local FILE=$1
+	local NEW
+
+	# escape correctly for use in sed
+	NEW=$(echo "${NEW_LINE}" | sed 's/\//\\\//g')
+	# create file if not exist...
+	touch "${FILE}"
+	# shellcheck disable=SC2016 # Errored part needs to be between single quotes
+	sed -i '/'"${SEARCH_FOR}"'/{s/.*/'"${NEW}"'/;h};${x;/./{x;q100};x}' "${FILE}"
+	if [[ $? -ne 100 ]] && [[ ${NEW_LINE} != '' ]]
+	then
+		echo "${NEW_LINE}" >> "${FILE}"
+	fi
+}
+
+#
+# Remove configuration line if exist
+# $1 = SEARCH_FOR
+# $3 = FILE - filepath to remove from
+#
+remove_config_line() {
+	local SEARCH_FOR=$1; shift
+	local FILE=$1
+
+	sed -i '/'"${SEARCH_FOR}"'/d' "${FILE}"
+}
+
 # 
 # Get latest ubuntu cloud image from distribution server
 # $1 = RELEASE

--- a/build/scripts/ipdk_default.env
+++ b/build/scripts/ipdk_default.env
@@ -1,30 +1,26 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# SCRIPT_DIR contains the directory of the calling ipdk script
+# SCRIPT_DIR contains the directory of the 'source'ing ipdk script
+# Define the pre configured (docker container) runtime environments
+# Add new definitions at the end of the array.
+# BASE_IMAGE,IMAGE_NAME,DOCKERFILE
+declare -gA RT_ENVS
+RT_ENVS["fedora33"]="fedora:33,ipdk/p4-ovs-fc33,${SCRIPT_DIR}/../Dockerfile.fedora"
+RT_ENVS["ubuntu2004"]="ubuntu:20.04,ipdk/p4-ovs-ubuntu20.04,${SCRIPT_DIR}/../Dockerfile.ubuntu"
+RT_ENVS["ubuntu1804"]="ubuntu:18.04,ipdk/p4-ovs-ubuntu18.04,${SCRIPT_DIR}/../Dockerfile.ubuntu"
 
 # Build parameters
 NO_CACHE=false                          # build with cache (true/false)
 PROXY=                                  # http/s proxy to use <Your Proxy>
 KEEP_SOURCE_CODE=false                  # Keep source code in image after build
                                         # (true/false(default))
-
-# When using fedora33
-BASE_IMG=fedora:33                      # Fedora base image to use
-IMAGE_NAME=ipdk/p4-ovs-fc33             # Name of the build container image
-DOCKERFILE=${SCRIPT_DIR}/../Dockerfile.fedora
-
-# When using ubuntu20.04
-#BASE_IMG=ubuntu:20.04
-#IMAGE_NAME=ipdk/p4-ovs-ubuntu20.04
-#DOCKERFILE=${SCRIPT_DIR}/../Dockerfile.ubuntu
-
-# When using ubuntu18.04
-#BASE_IMG=ubuntu:18.04
-#IMAGE_NAME=ipdk/p4-ovs-ubuntu18.04
-#DOCKERFILE=${SCRIPT_DIR}/../Dockerfile.ubuntu
-
-TAG=`git rev-parse --short HEAD`        # TAG part of the container image name 
+# Default base image reference setup (Fedora Core 33)
+IFS="," read -r -a ENV_ATTR <<< "${RT_ENVS[fedora33]}"
+BASE_IMG="${ENV_ATTR[0]}"               # Base image to use
+IMAGE_NAME="${ENV_ATTR[1]}"             # Name of the build container image
+DOCKERFILE="${ENV_ATTR[2]}"             # Path to the Dockerfile to use
+TAG=$(git rev-parse --short HEAD)       # TAG part of the container image name 
 
 # start parameters
 AS_DAEMON=false                         # run IPDK image as daemon container


### PR DESCRIPTION
This option adds the option to configure IPDK CLI to a predefined IPDK runtime environment as described in #72. The current predefined IPDK runtime environments are:
- default: configure the default environment (currently Fedora33 container)
- host: configure for a Vagrant/other VM or bare metal environment
- fedora33: fedora core 33 container environment
- ubuntu2004: ubuntu 20.04 container environment
- ubuntu1804: ubuntu 18.04 container environment

The `host` environment option is a preparation for another development to integrate the Vagrant and Bare metal flow in the CLI.