### PR TITLE
build: install protobuf grpc plugin

### DIFF
--- a/build/Dockerfile.ubuntu
+++ b/build/Dockerfile.ubuntu
@@ -52,6 +52,7 @@ RUN apt-get install -y apt-utils \
     libexpat1-dev \
     libboost-dev \
     libprotobuf-dev \
+    protobuf-compiler-grpc \
     protobuf-compiler \
     google-perftools \
     curl \


### PR DESCRIPTION
The [`protobuf-compiler-grpc`](https://packages.debian.org/sid/amd64/protobuf-compiler-grpc/filelist) package provides the `grpc_cpp_plugin` binary dependency.

```bash
protoc -I./external/googleapis -I/usr/local/include -I./p4runtime/proto --grpc_out=./p4proto/p4rt/proto --plugin=protoc-gen-grpc=`which grpc_cpp_plugin` ./p4runtime/proto/p4/v1/p4runtime.proto
: program not found or is not executable
--grpc_out: protoc-gen-grpc: Plugin failed with status code 1.
```

This problem has been reported in: https://github.com/ipdk-io/ipdk/issues/76