### PR TITLE
ipdk: Fix issue 82

### DIFF
--- a/build/Dockerfile.ubuntu
+++ b/build/Dockerfile.ubuntu
@@ -51,9 +51,6 @@ RUN apt-get install -y apt-utils \
     libgmp-dev \
     libexpat1-dev \
     libboost-dev \
-    libprotobuf-dev \
-    protobuf-compiler-grpc \
-    protobuf-compiler \
     google-perftools \
     curl \
     connect-proxy \
@@ -77,7 +74,8 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     scapy \
     six \
     cmake>=3.15.0 \
-    meson==0.59.4
+    meson==0.59.4 \
+    ninja>=1.8.2
 
 FROM base AS p4-ovs-container
 ARG KEEP_SOURCE_CODE

--- a/build/start_p4ovs.sh
+++ b/build/start_p4ovs.sh
@@ -18,6 +18,10 @@ SCRIPTS_DIR=/root/scripts
 export PATH="/root/scripts/:${PATH}"
 export PATH="$WORKDIR/P4-OVS/:${PATH}"
 
+# shellcheck source=scripts/os_ver_details.sh
+. ${SCRIPTS_DIR}/os_ver_details.sh
+get_os_ver_details
+
 get_p4ovs_repo() {
     chmod +x ${SCRIPTS_DIR}/get_p4ovs_repo.sh && \
         sh ${SCRIPTS_DIR}/get_p4ovs_repo.sh "$WORKDIR"
@@ -29,13 +33,13 @@ build_p4sde() {
 }
 
 install_dependencies() {
-    if [ "${OS}" = "Ubuntu" ]; then
+    if [ "$OS" = "Ubuntu" ]; then
         cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
             sed -i s/v3.6.1/v3.7.1/g install_dep_packages.sh && \
             sed -i s/v1.17.2/v1.27.1/g install_dep_packages.sh && \
-            ./install_dep_packages.sh "$WORKDIR"
+            sh ./install_dep_packages.sh "$WORKDIR"
     else
-     cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
+        cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
         sh ./install_dep_packages.sh "$WORKDIR"
     fi
     #...Removing Dependencies Source Code After Successful Installation...#


### PR DESCRIPTION
On older bash versions == operator doesn't work with [..] operator.
Due to this, depending on bash versions on your system,
install_dep_packages.sh script which install gflags and other
important dependencies will not run and you will run into packages
missing issue. This patch also minimum requirement for ninja version
based on meson requirement otherwise build will fail with error "
Could not detect Ninja v1.8.2 or newer"

Title: Fix issue 82
Change-type: DefectResolution
Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>