### PR TITLE
ipdk: Changes required to make P4C compatible with updated protobuf

### DIFF
--- a/build/Dockerfile.fedora
+++ b/build/Dockerfile.fedora
@@ -72,5 +72,6 @@ COPY ./scripts scripts
 COPY ./examples /root/examples
 COPY ./start_p4ovs.sh /root/start_p4ovs.sh 
 COPY ./run_ovs_cmds /root/run_ovs_cmds
+COPY ./patches /root/patches
 RUN  /root/start_p4ovs.sh /root && \
      /root/scripts/run_cleanup.sh /root ${KEEP_SOURCE_CODE}

--- a/build/Dockerfile.ubuntu
+++ b/build/Dockerfile.ubuntu
@@ -84,5 +84,6 @@ COPY ./scripts scripts
 COPY ./examples /root/examples
 COPY ./start_p4ovs.sh /root/start_p4ovs.sh
 COPY ./run_ovs_cmds /root/run_ovs_cmds
+COPY ./patches /root/patches
 RUN  /root/start_p4ovs.sh /root && \
      /root/scripts/run_cleanup.sh /root ${KEEP_SOURCE_CODE}

--- a/build/patches/PATCH-01-P4C
+++ b/build/patches/PATCH-01-P4C
@@ -1,0 +1,14 @@
+diff --git a/control-plane/p4RuntimeSerializer.cpp b/control-plane/p4RuntimeSerializer.cpp
+index d50f155d0..4402ce74e 100644
+--- a/control-plane/p4RuntimeSerializer.cpp
++++ b/control-plane/p4RuntimeSerializer.cpp
+@@ -148,7 +148,8 @@ static bool writeJsonTo(const Message& message, std::ostream* destination) {
+     options.add_whitespace = true;
+
+     std::string output;
+-    if (MessageToJsonString(message, &output, options) != Status::OK) {
++    Status status = MessageToJsonString(message, &output, options);
++    if (status.ok()) {
+         ::error(ErrorType::ERR_IO,
+                 "Failed to serialize protobuf message to JSON");
+         return false;

--- a/build/scripts/build_p4c.sh
+++ b/build/scripts/build_p4c.sh
@@ -38,6 +38,7 @@ git checkout $P4C_SHA
 #public method (ok()) is available to check the return status.
 #This patch applies necessary changes to P4C code to accomodate
 #this change
+#TODO: See if this patch can be upstreamed to p4lang
 git apply $PATCH_DIR/PATCH-01-P4C
 mkdir build && cd build
 cmake -DENABLE_BMV2=OFF \ -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF \

--- a/build/scripts/build_p4c.sh
+++ b/build/scripts/build_p4c.sh
@@ -17,6 +17,7 @@ fi
 P4C_SHA=d2f0c2a22286c6b6643e5e3906cf020d6d698c70
 
 WORKDIR=$1
+PATCH_DIR=/root/patches
 cd "$WORKDIR"
 
 echo "Removing P4C directory if it already exits"
@@ -32,6 +33,12 @@ echo ""
 git clone https://github.com/p4lang/p4c.git --recursive P4C
 cd P4C
 git checkout $P4C_SHA
+#In protobuf version 3.18.1,'OK’ is no longer a member of
+#‘google::protobuf::util::status_internal::Status’. Instead a
+#public method (ok()) is available to check the return status.
+#This patch applies necessary changes to P4C code to accomodate
+#this change
+git apply $PATCH_DIR/PATCH-01-P4C
 mkdir build && cd build
 cmake -DENABLE_BMV2=OFF \ -DENABLE_P4C_GRAPHS=OFF -DENABLE_P4TEST=OFF \
       -DENABLE_GTESTS=OFF ..

--- a/build/start_p4ovs.sh
+++ b/build/start_p4ovs.sh
@@ -18,10 +18,6 @@ SCRIPTS_DIR=/root/scripts
 export PATH="/root/scripts/:${PATH}"
 export PATH="$WORKDIR/P4-OVS/:${PATH}"
 
-# shellcheck source=scripts/os_ver_details.sh
-. ${SCRIPTS_DIR}/os_ver_details.sh
-get_os_ver_details
-
 get_p4ovs_repo() {
     chmod +x ${SCRIPTS_DIR}/get_p4ovs_repo.sh && \
         sh ${SCRIPTS_DIR}/get_p4ovs_repo.sh "$WORKDIR"
@@ -33,15 +29,8 @@ build_p4sde() {
 }
 
 install_dependencies() {
-    if [ "$OS" = "Ubuntu" ]; then
-        cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
-            sed -i s/v3.6.1/v3.7.1/g install_dep_packages.sh && \
-            sed -i s/v1.17.2/v1.27.1/g install_dep_packages.sh && \
-            sh ./install_dep_packages.sh "$WORKDIR"
-    else
-        cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
+    cd "$WORKDIR"/P4-OVS && sed -i 's/sudo //g' install_dep_packages.sh && \
         sh ./install_dep_packages.sh "$WORKDIR"
-    fi
     #...Removing Dependencies Source Code After Successful Installation...#
     rm -rf "${WORKDIR}/P4OVS_DEPS_SRC_CODE" || exit 1
 }


### PR DESCRIPTION
    This patch introduce required changes to make P4C compatible with
    protobuf 3.18.x. Updated dependencies are compatible with Ubuntu as well
    as Fedora versions

Title: Changes required to make P4C compatible with updated protobuf
Change-type: Other
Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>