### PR TITLE
os_ver_details.sh: Always add -j to NUM_THREADS

### DIFF
--- a/build/scripts/os_ver_details.sh
+++ b/build/scripts/os_ver_details.sh
@@ -60,10 +60,10 @@ get_num_cores()
            NUM_THREADS=$((NUM_CORES / 4))
            NUM_THREADS=-j$NUM_THREADS
        else
-           NUM_THREADS=${NUM_CORES}
+           NUM_THREADS=-j${NUM_CORES}
        fi
     else
         NUM_CORES=1
-        NUM_THREADS=1
+        NUM_THREADS=-j1
     fi
 }


### PR DESCRIPTION
Fixes os_ver_details.sh to always add -j in front of the number of
threads since this is passed directly to make.

Closes #85

Signed-off-by: Kyle Mestery <mestery@mestery.com>