### PR TITLE
README: Make build instructions explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ for increasing performance, optimizing resources and securing the
 infrastructure as an open source community.
 
 ![IPDK Architecture](https://github.com/ipdk-io/ipdk-io.github.io/blob/main/img/ipdk-icons-white.png)
+
+## Building and Using IPDK
+
+Instructions for how to build IPDK are found in the
+[build directory](build/README.md). Follow those to build and use IPDK.

--- a/build/README.md
+++ b/build/README.md
@@ -5,3 +5,8 @@ two ways to build and run IPDK:
 
 * [IPDK Container](README_DOCKER.md)
 * [IPDK Native](README_NATIVE.md)
+
+If you are comfortable with Docker and have it installed and working, you
+should follow the [IPDK Container](README_DOCKER.md) build instructions.  If
+you want to experiment with IPDK running natively in either a VM or on a bare
+metal host, you should follow the [IPDK Native](README_NATIVE.md) instructions.


### PR DESCRIPTION
This makes the IPDK build instructions much clearer by putting a note in
the top-level README.md file on how to perform a build.

Signed-off-by: Kyle Mestery <mestery@mestery.com>