### PR TITLE
Improve IPDK cli and ci build/run with buildx, multiarch, artefacts and push to registries

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  # if workflow for PR or push is already running stop it, and start new one
+  group: makefile-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
@@ -15,31 +20,85 @@ jobs:
     - name: shellcheck
       run: make -C build shellcheck
 
-  build:
+  build_containers:
     needs: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
+        # for OCI runner change to: runner: [ubuntu-latest, self-hosted]
+        runner: [ubuntu-latest]
         os: [ubuntu2004, fedora33]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-        sudo echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
-        sudo apt-get -y install apt-utils
+    - name: Set up QEMU        
+      uses: docker/setup-qemu-action@v1
 
-    - name: Install Docker CE
-      run: |
-        sudo apt-get install ca-certificates curl gnupg lsb-release
-        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-        sudo apt-get update
-        sudo apt-get install docker-ce docker-ce-cli containerd.io
+    - name: Set up Docker Buildx        
+      uses: docker/setup-buildx-action@v1
 
-    - name: Container Build
+#    - name: Login to DockerHub
+#      if: github.event_name != 'pull_request'
+#      uses: docker/login-action@v1 
+#      with:
+#        username: ${{ secrets.DOCKERHUB_USERNAME }}
+#        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Login to GitHub Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create tags and labels
+      id: image_meta
+      uses: docker/metadata-action@v3
+      with:
+        sep-tags: ","
+        sep-labels: ","
+        # list of names to use as base name for tags
+        images: |
+          ipdk-io/ipdk-${{ matrix.os }}-${{ runner.arch }}
+          ghcr.io/${{ github.repository_owner }}/ipdk-${{ matrix.os }}-${{ runner.arch }}
+        # Docker tags based on the following events/attributes
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=sha
+
+    - name: Install IPDK cli
       run: |
         cd build
         ./ipdk install ${{ matrix.os }}
-        ipdk build --no-cache
+ 
+    - name: IPDK image build and push
+      if: github.event_name != 'pull_request'
+      run: |
+        ipdk build --no-cache \
+          --tags ${{ steps.image_meta.outputs.tags }} \
+          --labels ${{ steps.image_meta.outputs.labels }} \
+          --push
+
+    - name: IPDK image build and export
+      if: github.event_name == 'pull_request'
+      run: |
+        ipdk build --no-cache \
+          --tags ${{ steps.image_meta.outputs.tags }} \
+          --labels ${{ steps.image_meta.outputs.labels }} \
+          --export /tmp/${{ matrix.os }}-${{ runner.arch }}.tar
+
+    - name: Upload build artifact
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.os }}-${{ runner.arch }}
+        path: /tmp/${{ matrix.os }}-${{ runner.arch }}.tar
+        retention-days: 1

--- a/build/scripts/ipdk-lib.sh
+++ b/build/scripts/ipdk-lib.sh
@@ -27,13 +27,13 @@ function check_buildx() {
 		return 1
 	fi
 
-	docker_version="$(docker --version | cut -d' ' -f3 | tr -cd '0-9.')"
+	docker_version="$(docker version --format '{{.Server.Version}}')"
 	if [[ "$(version "$docker_version")" < "$(version '19.03')" ]]; then
 		error "docker $docker_version too old. Need >= 19.03"
 		return 1
 	fi
 
-	docker_experimental="$(docker version | awk '/^ *Experimental:/ {print $2 ; exit}')"
+	docker_experimental="$(docker version --format='{{.Server.Experimental}}')"
 	if [[ "$docker_experimental" != 'true' ]]; then
 		echo "docker experimental flag not enabled: Set with 'export DOCKER_CLI_EXPERIMENTAL=enabled'" >&2
 		return 1

--- a/build/scripts/ipdk-lib.sh
+++ b/build/scripts/ipdk-lib.sh
@@ -13,6 +13,73 @@ print_banner() {
 	echo ""
 }
 
+
+function version() {
+	printf '%02d' "$(echo "$1" | tr . ' ' | sed -e 's/ 0*/ /g')" 2>/dev/null
+}
+
+#
+# Check if docker buildx is usable
+#
+function check_buildx() {
+	if ! command -v docker >/dev/null 2>&1; then
+		echo "Can't find docker. Install first!!" >&2
+		return 1
+	fi
+
+	docker_version="$(docker --version | cut -d' ' -f3 | tr -cd '0-9.')"
+	if [[ "$(version "$docker_version")" < "$(version '19.03')" ]]; then
+		error "docker $docker_version too old. Need >= 19.03"
+		return 1
+	fi
+
+	docker_experimental="$(docker version | awk '/^ *Experimental:/ {print $2 ; exit}')"
+	if [[ "$docker_experimental" != 'true' ]]; then
+		echo "docker experimental flag not enabled: Set with 'export DOCKER_CLI_EXPERIMENTAL=enabled'" >&2
+		return 1
+	fi
+
+	kernel_version="$(uname -r)"
+	if [[ "$(version "$kernel_version")" < "$(version '4.8')" ]]; then
+		echo "Kernel $kernel_version too old, need >= 4.8 to build with --platform." >&2
+		return 1
+	fi
+
+	if [[ "$(mount | grep -c '/proc/sys/fs/binfmt_misc')" == '0' ]]; then
+		echo "/proc/sys/fs/binfmt_misc not mounted." >&2
+		return 1
+	fi
+
+	if ! command -v update-binfmts >/dev/null 2>&1; then
+		echo "Can't find update-binfmts." >&2
+		return 1
+	fi
+
+	binfmt_version="$(update-binfmts --version | awk '{print $NF}')"
+	if [[ "$(version "$binfmt_version")" < "$(version '2.1.7')" ]]; then
+		echo "update-binfmts $binfmt_version too old. Need >= 2.1.7" >&2
+		return 1
+	fi
+
+	if [[ ! -e '/proc/sys/fs/binfmt_misc/qemu-aarch64' ]]; then
+		# Skip this test if QEMU isn't registered with binfmt_misc. It might
+		# come from a docker image rather than the host file system.
+		if [[ ! -e '/usr/bin/qemu-aarch64-static' ]]; then
+			echo "Missing QEMU."  >&2
+			return 1
+		fi
+	fi
+	if [[ ! -e '/proc/sys/fs/binfmt_misc/qemu-aarch64' ]]; then
+		echo "QEMU not registered in binfmt_misc." >&2
+		return 1
+	fi
+	flags="$(grep 'flags:' /proc/sys/fs/binfmt_misc/qemu-aarch64 | cut -d' ' -f2)"
+	if [[ "$(echo "$flags" | grep -c F)" == '0' ]]; then
+		echo "QEMU not registered in binfmt_misc with fix-binary (F) flag." >&2
+		return 1
+	fi
+}
+
 #
 # Replace configuration line with new line and if not exist add
 # $1 = SEARCH_FOR

--- a/build/scripts/ipdk_default.env
+++ b/build/scripts/ipdk_default.env
@@ -6,9 +6,9 @@
 # Add new definitions at the end of the array.
 # BASE_IMAGE,IMAGE_NAME,DOCKERFILE
 declare -gA RT_ENVS
-RT_ENVS["fedora33"]="fedora:33,ipdk/p4-ovs-fc33,${SCRIPT_DIR}/../Dockerfile.fedora"
-RT_ENVS["ubuntu2004"]="ubuntu:20.04,ipdk/p4-ovs-ubuntu20.04,${SCRIPT_DIR}/../Dockerfile.ubuntu"
-RT_ENVS["ubuntu1804"]="ubuntu:18.04,ipdk/p4-ovs-ubuntu18.04,${SCRIPT_DIR}/../Dockerfile.ubuntu"
+RT_ENVS["fedora33"]="fedora:33,ipdk-io/ipdk-fedora33,${SCRIPT_DIR}/../Dockerfile.fedora"
+RT_ENVS["ubuntu2004"]="ubuntu:20.04,ipdk-io/ipdk-ubuntu2004,${SCRIPT_DIR}/../Dockerfile.ubuntu"
+RT_ENVS["ubuntu1804"]="ubuntu:18.04,ipdk-io/ipdk-ubuntu1804,${SCRIPT_DIR}/../Dockerfile.ubuntu"
 
 # Build parameters
 NO_CACHE=false                          # build with cache (true/false)
@@ -20,7 +20,9 @@ IFS="," read -r -a ENV_ATTR <<< "${RT_ENVS[fedora33]}"
 BASE_IMG="${ENV_ATTR[0]}"               # Base image to use
 IMAGE_NAME="${ENV_ATTR[1]}"             # Name of the build container image
 DOCKERFILE="${ENV_ATTR[2]}"             # Path to the Dockerfile to use
-TAG=$(git rev-parse --short HEAD)       # TAG part of the container image name 
+TAG=sha-$(git rev-parse --short HEAD)   # TAG part of the container image name
+PUSH=false                              # Do not push to registries
+EXPORT=false                            # Do not export image to file
 
 # start parameters
 AS_DAEMON=false                         # run IPDK image as daemon container


### PR DESCRIPTION
Implements large parts of #101

Expanded IPDK CLI commands and options with:
- Support `ipdk config [key]=[value]` for setting key=value in ~/.ipdk/ipdk.env
- Support `ipdk build --platform [docker buildx supported platforms]` for local and multiarch builds
- Support `ipdk build --tags [taglist] --labels [labellist] --push --export [filename]`
- Support `ipdk start --platform [docker buildx supported platform]`
- Support `ipdk tag [tag]` for local image builds
- Support `ipdk export [filename]` for local image builds
- Support `ipdk push [tag]` for local image builds
- check for support of `docker buildx` on host system

Example:
`ipdk build --no-cache --platform linux/arm64` builds a ARM64 based ipdk image if run on a linux/amd-64 based host system
`ipdk start --platform linux/arm64` starts a ARM64 based image on a linux/amd-64 based host system by using qemu emulation

Expanded the Github `makefile.yml` action file with:
- concurrency option to prevent running multiple build actions for the same PR or push.
- install of qemu runtimes
- install of buildx
- (for now disabled) login to dockerhub
- login to Github Container Registry (ghcr)
- create build metadata (tags and labels)
- use ipdk cli build command
- push the created multiarch container images to the registries when run from push
- upload created multiarch container images as artefacts when the action is run from PR
- Currently only building containers for one architecture platform (linux/amd-64)

Signed-off-by: stolsma <github@tolsma.net>