### PR TITLE
shellcheck: Fix shellcheck to actually run

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -8,4 +8,4 @@
 help:;@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 #awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
 
-shellcheck: ;shellcheck -x `find . -name "*.sh"`
+shellcheck: ;./scripts/run-shellcheck.sh

--- a/build/scripts/run-shellcheck.sh
+++ b/build/scripts/run-shellcheck.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Simple script to find all bash scripts and run shellcheck on them
+#
+
+set -eu
+
+is_bash() {
+    [[ $1 == *.sh ]] && return 0
+    [[ $1 == */bash-completion/* ]] && return 0
+    [[ $(file -b --mime-type "$1") == text/x-shellscript ]] && return 0
+    return 1
+}
+
+while IFS= read -r -d $'' file; do
+    if is_bash "$file"; then
+        shellcheck -x -W0 -s bash "$file" || continue
+    fi
+done < <(find . -type f \! -path "./.git/*" -print0)


### PR DESCRIPTION
This adds a simple script to wrap around shellcheck which finds all bash
scripts and runs shellcheck on them. It is inspired by [1].

Prior to this, the CI was not actually running shellcheck on any scripts
in the scripts directory.

[1] https://github.com/koalaman/shellcheck/issues/143#issuecomment-909009632

Signed-off-by: Kyle Mestery <mestery@mestery.com>