### PR TITLE
ipdk: support various-sized hugepages

### DIFF
--- a/build/scripts/set_hugepages.sh
+++ b/build/scripts/set_hugepages.sh
@@ -8,30 +8,46 @@ if [ "$(mount | grep hugetlbfs)" == "" ]
 then
 	mount -t hugetlbfs nodev /mnt/huge
 fi
-if [ "$(grep huge < /etc/fstab)" == "" ]
-then
-	echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
+
+if [ -e /etc/fstab ]; then
+        if [ "$(grep huge < /etc/fstab)" == "" ]
+        then
+                echo -e "nodev /mnt/huge hugetlbfs\n" >> /etc/fstab
+        fi
 fi
+
+# Get pagesize in MegaBytes, take only 1st result (head -1):
+pagesizeM=$(cat /proc/mounts | grep hugetlbfs | head -1)
+# Remove Prefix of = from: hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=512M 0 0
+pagesizeM=${pagesizeM#*=}
+# Remove Suffix of M from: hugetlbfs /dev/hugepages hugetlbfs rw,relatime,pagesize=512M 0 0
+pagesizeM=${pagesizeM%M*}
+
+# 2 GB Total size
+total_sizeM=`expr 2048`
+num_pages=`expr $total_sizeM / $pagesizeM`
+pagesizeKB=`expr $pagesizeM \* 1024`
 
 if [ "$(grep nr_hugepages < /etc/sysctl.conf)" == "" ]
 then
-	echo "vm.nr_hugepages = 1024" >> /etc/sysctl.conf
-	#sysctl -p /etc/sysctl.conf
+        echo "vm.nr_hugepages = ${num_pages}" >> /etc/sysctl.conf
+        #sysctl -p /etc/sysctl.conf
 fi
 
 #
 # Check if the kernel/mm version of hugepages exists, and set hugepages if so.
 #
-if [ -d /sys/kernel/mm/hugepages/hugepages-2048kB ] ; then
-	echo 1024 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+if [ -d /sys/kernel/mm/hugepages/hugepages-${pagesizeKB}kB ] ; then
+        echo ${num_pages} | tee /sys/kernel/mm/hugepages/hugepages-${pagesizeKB}kB/nr_hugepages
 fi
 
 #
 # Check if the node version of hugepages exists, and set hugepages if so.
 #
-if [ -d /sys/devices/system/node/node0/hugepages/hugepages-2048kB ] ; then
-	echo 1024 | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+if [ -d /sys/devices/system/node/node0/hugepages/hugepages-${pagesizeKB}kB ] ; then
+        echo ${num_pages} | sudo tee /sys/devices/system/node/node0/hugepages/hugepages-${pagesizeKB}kB/nr_hugepages
 fi
-if [ -d /sys/devices/system/node/node1/hugepages/hugepages-2048kB ] ; then
-	echo 1024 | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-2048kB/nr_hugepages
+if [ -d /sys/devices/system/node/node1/hugepages/hugepages-${pagesizeKB}kB ] ; then
+        echo ${num_pages} | sudo tee /sys/devices/system/node/node1/hugepages/hugepages-${pagesizeKB}kB/nr_hugepages
 fi
+


### PR DESCRIPTION
According to available hugepages configuration under /proc/mounts,
configure the required amount of pages so as to have 2GB total.

Signed-off-by: Asaf Ravid <aravid@marvell.com>