### PR TITLE
Fix docker experimental check

### DIFF
--- a/build/scripts/ipdk-lib.sh
+++ b/build/scripts/ipdk-lib.sh
@@ -35,18 +35,7 @@ function check_buildx() {
 
 	docker_experimental="$(docker version --format='{{.Server.Experimental}}')"
 	if [[ "$docker_experimental" != 'true' ]]; then
-		# Try to enable experimental support
-		dockerexp=$(sudo mktemp)
-		sudo jq '.+{experimental:true}' /etc/docker/daemon.json | sudo tee -a "$dockerexp"
-		sudo mv "$dockerexp" /etc/docker/daemon.json
-		sudo systemctl restart docker.service
-
-		# Reverify
-		docker_experimental="$(docker version --format='{{.Server.Experimental}}')"
-		if [[ "$docker_experimental" != 'true' ]]; then
-			echo "docker experimental flag not enabled: Set with 'export DOCKER_CLI_EXPERIMENTAL=enabled'" >&2
-			return 1
-		fi
+		export DOCKER_CLI_EXPERIMENTAL=enabled
 	fi
 
 	kernel_version="$(uname -r)"


### PR DESCRIPTION
Just follow the echo comment and use the DOCKER_CLI_EXPERIMENTAL environment variable instead of trying to change the docker config file with external commands that could not be available on host systems.

Solves reported issues...

Signed-off-by: stolsma <github@tolsma.net>