### PR TITLE
location: Fixes from directory structure PR

### DIFF
--- a/build/networking/README_NATIVE.md
+++ b/build/networking/README_NATIVE.md
@@ -49,14 +49,14 @@ Without a proxy:
 
 ```
 vagrant@ubuntu2004:~$ sudo su -
-root@ubuntu2004:~# SCRIPT_DIR=/git/ipdk/build/scripts /git/ipdk/build/scripts/host_install.sh
+root@ubuntu2004:~# SCRIPT_DIR=/git/ipdk/build/networking/scripts /git/ipdk/build/networking/scripts/host_install.sh
 ```
 
 If using a proxy:
 
 ```
 vagrant@ubuntu2004:~$ sudo su -
-root@ubuntu2004:~# SCRIPT_DIR=/git/ipdk/build/scripts /git/ipdk/build/scripts/host_install.sh -p [proxy name]
+root@ubuntu2004:~# SCRIPT_DIR=/git/ipdk/build/networking/scripts /git/ipdk/build/networking/scripts/host_install.sh -p [proxy name]
 ```
 
 Note: To skip installing and building dependencies in the future, add a `-s`
@@ -65,7 +65,7 @@ flag to the host_install.sh script.
 ### Run the rundemo.sh script
 
 ```
-root@ubuntu2004:~$ /git/ipdk/build/scripts/rundemo.sh
+root@ubuntu2004:~$ /git/ipdk/build/networking/scripts/rundemo.sh
 ```
 
 5. Verify OVS is running:

--- a/build/networking/scripts/host_install.sh
+++ b/build/networking/scripts/host_install.sh
@@ -154,11 +154,11 @@ else
 fi
 
 pushd /root || exit
-cp -r /git/ipdk/build/scripts .
-cp -r /git/ipdk/build/examples .
-cp /git/ipdk/build/start_p4ovs.sh start_p4ovs.sh
-cp /git/ipdk/build/run_ovs_cmds run_ovs_cmds
-cp -r /git/ipdk/build/patches .
+cp -r /git/ipdk/build/networking/scripts .
+cp -r /git/ipdk/build/networking/examples .
+cp /git/ipdk/build/networking/start_p4ovs.sh start_p4ovs.sh
+cp /git/ipdk/build/networking/run_ovs_cmds run_ovs_cmds
+cp -r /git/ipdk/build/networking/patches .
 popd
 
 export OS_VERSION=20.04

--- a/build/networking/vagrant-container/Vagrantfile
+++ b/build/networking/vagrant-container/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
     v.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
   end
 
-  config.vm.synced_folder "../..", "/git/ipdk"
+  config.vm.synced_folder "../../..", "/git/ipdk"
 
   # NOTE: Configure any proxy below.
   #config.proxy.http     = "http://proxy:911"

--- a/build/networking/vagrant-native/Vagrantfile
+++ b/build/networking/vagrant-native/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
     v.customize ['modifyvm', :id, '--nested-hw-virt', 'on']
   end
 
-  config.vm.synced_folder "../..", "/git/ipdk"
+  config.vm.synced_folder "../../..", "/git/ipdk"
 
   # NOTE: Configure any proxy below.
   #config.proxy.http     = "http://proxy:911"


### PR DESCRIPTION
Commit 3ecf06e moved things around such that there is now a
`build/networking` directory. Some things were not adjusted to reflect
this new directory structure. This commit fixes these areas.

Signed-off-by: Kyle Mestery <mestery@mestery.com>