### PR TITLE
ipdk.sh: Use $CONTAINER_NAME instead of ipdk

### DIFF
--- a/build/scripts/ipdk.sh
+++ b/build/scripts/ipdk.sh
@@ -265,7 +265,7 @@ start_container() {
 		"${ARGS[@]}" -it "${IMAGE_NAME}":"${TAG}" "${RUN_COMMAND[@]}"
 
 	if [ "$LINK_NAMESPACE" ] ; then
-		IPDK_NAMESPACE=$(docker inspect -f '{{.State.Pid}}' ipdk)
+		IPDK_NAMESPACE=$(docker inspect -f '{{.State.Pid}}' "$CONTAINER_NAME")
 		sudo mkdir -p /var/run/netns
 		sudo ln -sf "/proc/${IPDK_NAMESPACE}/ns/net" /var/run/netns/switch
 	fi


### PR DESCRIPTION
Per Sander, use the variable container name.

Signed-off-by: Kyle Mestery <mestery@mestery.com>