### PR TITLE
p4-ebpf: Setup LD_LIBRARY_PATH correctly

### DIFF
--- a/build/networking_ebpf/scripts/host_install.sh
+++ b/build/networking_ebpf/scripts/host_install.sh
@@ -96,5 +96,11 @@ if [ ! -d psa-ebpf-demo ] ; then
 fi
 # NOTE: For now, just clone
 
+# Setup LD_LIBRARY_PATH
+echo "/root/ipdk-ebpf/psabpf/build" >> /etc/ld.so.conf.d/ipdk.conf
+echo "/root/ipdk-ebpf/psabpf/libbpf/build" >> /etc/ld.so.conf.d/ipdk.conf
+echo "LD_LIBRARY_PATH=/usr/local/lib:/root/ipdk-ebpf/psabpf/build:/root/ipdk-ebpf/psabpf/libbpf/build:$LD_LIBRARY_PATH" >> ~/.bashrc
+ldconfig
+
 # Final popd
 popd || exit


### PR DESCRIPTION
Now that [1] merged, psabpf-ctl is a shared library in addition to a CLI
tool. However, this means we should correctly setup LD_LIBRARY_PATH in
the p4-ebpf IPDK container. Without this, you cannot run psabpf-ctl, as
seen on these failing CI jobs in the opi-poc GitHub repo [2].

[1] https://github.com/P4-Research/psabpf/pull/31
[2] https://github.com/opiproject/opi-poc/actions/runs/2271748281

Signed-off-by: Kyle Mestery <mestery@mestery.com>