### PR TITLE
eBPF: Build psabpf as shared library

### DIFF
--- a/build/networking_ebpf/README.md
+++ b/build/networking_ebpf/README.md
@@ -41,9 +41,8 @@ This will install the following components of the IPDK eBPF recipe:
 * protobuf
 * P4 compiler with eBPF PSA support
 * psabpf CLI
-* psa-ebpf-demp
-* An old version of golang
-* ipdk-plugin Docker CNM
+* psa-ebpf-demo
+* ipdk-plugin Docker CNI
 
 ## Docker Instructions
 

--- a/build/networking_ebpf/scripts/host_install.sh
+++ b/build/networking_ebpf/scripts/host_install.sh
@@ -81,7 +81,7 @@ pushd psabpf || exit
 if [ ! -d build ] ; then
     ./build_libbpf.sh
     mkdir build && pushd build || exit
-    cmake ..
+    cmake -DBUILD_SHARED=on ..
     make -j4
     make install
     popd || exit


### PR DESCRIPTION
Commit [1] added proper shared library generation for psabpf. This
commit ensures IPDK p4-eBPF builds with the shared library support
enabled.

[1] https://github.com/P4-Research/psabpf/pull/34

Signed-off-by: Kyle Mestery <mestery@mestery.com>