### PR TITLE
Reuse run_vm script in storage integration tests

### DIFF
--- a/build/storage/scripts/vm/prepare_vm.sh
+++ b/build/storage/scripts/vm/prepare_vm.sh
@@ -10,14 +10,14 @@ set -e
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/..
 
 if [[ $# != 1 ]] ; then
-    echo "Directory to place vm file has to be specified"
+    echo "Disk to boot vm file has to be specified"
     exit 1
 fi
 
 export LIBGUESTFS_BACKEND=direct
 
-path_to_place_vm_file=${1}
-vm_file=${path_to_place_vm_file}/vm.qcow2
+vm_file="${1}"
+path_to_place_vm_file=$(dirname "$vm_file")
 
 if [ ! -f "${vm_file}" ]; then
     vm_tmp_file="${path_to_place_vm_file}/vm_original.qcow2"

--- a/build/storage/scripts/vm/run_vm.sh
+++ b/build/storage/scripts/vm/run_vm.sh
@@ -9,20 +9,27 @@
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/..
 
 SHARED_VOLUME=${SHARED_VOLUME:-.}
+DRIVE_TO_BOOT=${DRIVE_TO_BOOT:-${SHARED_VOLUME}/vm.qcow2}
+qemu_serial="-serial stdio"
+if [ -n "$UNIX_SERIAL" ]; then
+  qemu_serial="-serial unix:${SHARED_VOLUME}/${UNIX_SERIAL},server,nowait"
+fi
 
-bash "${scripts_dir}"/vm/prepare_vm.sh "${SHARED_VOLUME}"
-bash "${scripts_dir}"/allocate_hugepages.sh
+"${scripts_dir}"/vm/prepare_vm.sh "${DRIVE_TO_BOOT}"
+"${scripts_dir}"/allocate_hugepages.sh
 
 run_vm="sudo qemu-system-x86_64 \
+  ${qemu_serial} \
   --enable-kvm \
   -cpu host \
   -m 1G -object memory-backend-file,id=mem0,size=1G,mem-path=/dev/hugepages,share=on -numa node,memdev=mem0 \
   -smp 2 \
-  -drive file=${SHARED_VOLUME}/vm.qcow2,if=none,id=disk \
+  -drive file=${DRIVE_TO_BOOT},if=none,id=disk \
   -device ide-hd,drive=disk,bootindex=0 \
   -net nic -net tap,script=${scripts_dir}/vm/create_nat_for_vm.sh,\
 downscript=${scripts_dir}/vm/delete_nat_for_vm.sh \
   -monitor unix:${SHARED_VOLUME}/vm_monitor,server,nowait \
-  --nographic"
+  --nographic \
+  $*"
 
 $run_vm

--- a/build/storage/tests/it/test-drivers/init.hot-plug
+++ b/build/storage/tests/it/test-drivers/init.hot-plug
@@ -12,6 +12,7 @@ declare vm_serial
 declare nqn
 declare storage_target_ip
 declare proxy_ip
+declare vm_monitor
 # shellcheck disable=SC1091
 source "${current_script_dir}"/test-helpers
 
@@ -34,7 +35,6 @@ log_in_with_default_credentials "${vm_serial}"
 
 is_virtio_blk_not_attached "${vm_serial}"
 
-vm_monitor=vm_monitor_socket
 virtio_blk_0_socket=VirtioBlk0
 echo ""
 echo "### Attach 3 virtio-blk devices ###"

--- a/build/storage/tests/it/test-drivers/test-helpers
+++ b/build/storage/tests/it/test-drivers/test-helpers
@@ -73,4 +73,4 @@ export proxy_ip="${proxy_ip}"
 export nqn="nqn.2016-06.io.spdk:cnode1"
 export shared_volume=/ipdk-shared
 export vm_serial=${shared_volume}/vm_socket
-export vm_monitor=${shared_volume}/vm_monitor_socket
+export vm_monitor=${shared_volume}/vm_monitor

--- a/build/storage/tests/it/traffic-generator/Dockerfile
+++ b/build/storage/tests/it/traffic-generator/Dockerfile
@@ -4,37 +4,31 @@
 # NOTICE: THIS FILE HAS BEEN MODIFIED BY INTEL CORPORATION UNDER COMPLIANCE
 # WITH THE APACHE 2.0 LICENSE FROM THE ORIGINAL WORK
 #
-FROM fedora:36 as traffic-generator-base
-
+FROM fedora:36 as base
+ARG DRIVE_TO_BOOT=/vm.qcow2
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
-
+ENV DRIVE_TO_BOOT=$DRIVE_TO_BOOT
 ENV http_proxy=$HTTP_PROXY
 ENV https_proxy=$HTTPS_PROXY
 ENV no_proxy=$NO_PROXY
+
+FROM base as traffic-generator-base
 
 RUN dnf install -y wget
 RUN dnf install -y libguestfs-tools-c
 
-COPY scripts/* /scripts/
-COPY scripts/vm/* /scripts/vm/
-RUN WITHOUT_HOST_TARGET=true /scripts/vm/prepare_vm.sh /
+COPY scripts/vm/prepare_vm.sh /scripts/vm/prepare_vm.sh
+RUN WITHOUT_HOST_TARGET=true /scripts/vm/prepare_vm.sh $DRIVE_TO_BOOT
 
-FROM fedora:36 AS traffic-generator
-
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG NO_PROXY
-
-ENV http_proxy=$HTTP_PROXY
-ENV https_proxy=$HTTPS_PROXY
-ENV no_proxy=$NO_PROXY
+FROM base AS traffic-generator
 
 RUN dnf install -y qemu-kvm
+RUN dnf install -y iproute dnsmasq
 COPY tests/it/traffic-generator/init /init
-RUN chmod +x /init
-COPY --from=traffic-generator-base /vm.qcow2 /vm.qcow2
-
-
+COPY --from=traffic-generator-base $DRIVE_TO_BOOT $DRIVE_TO_BOOT
+COPY /scripts /scripts
+ENV SHARED_VOLUME=/ipdk-shared
+ENV UNIX_SERIAL=vm_socket
 ENTRYPOINT ["/init"]

--- a/build/storage/tests/it/traffic-generator/init
+++ b/build/storage/tests/it/traffic-generator/init
@@ -6,8 +6,7 @@
 
 [ "$DEBUG" == 'true' ] && set -x ; export DEBUG_VM=true
 
-shared_volume=/ipdk-shared
-virtio_blk_socket=${shared_volume}/VirtioBlk0
+virtio_blk_socket="${SHARED_VOLUME}/VirtioBlk0"
 
 
 attach_default_virtio_blk=" \
@@ -19,12 +18,12 @@ if [ "${DO_NOT_ATTACH_VIRTIO_BLK}" == "true" ]; then
 else
     wait_counter=1
 
-    while [ ! -S  ${virtio_blk_socket} ] && [ ${wait_counter} -le 10 ] ; do
+    while [ ! -S  "${virtio_blk_socket}" ] && [ ${wait_counter} -le 10 ] ; do
 		echo "Wait for virtio-blk socket: ${virtio_blk_socket}"
 		sleep 5
 		wait_counter=$(( wait_counter + 1 ))
     done
-    if [ ! -S  ${virtio_blk_socket} ] ; then
+    if [ ! -S  "${virtio_blk_socket}" ] ; then
 		echo "ERROR virtio-blk socket is not detected: ${virtio_blk_socket}"
 		exit 1
 	else
@@ -36,20 +35,6 @@ fi
 
 echo "Starting vm"
 
-run_qemu="qemu-kvm \
-${attach_default_virtio_blk}
---enable-kvm \
--cpu host \
--m 1G \
--smp 2 \
--drive file=vm.qcow2,if=none,id=disk \
--device ide-hd,drive=disk,bootindex=0 \
--object memory-backend-file,id=mem0,size=1G,mem-path=/dev/hugepages,share=on \
--numa node,memdev=mem0 \
--monitor unix:${shared_volume}/vm_monitor_socket,server,nowait \
--serial unix:${shared_volume}/vm_socket,server,nowait \
---nographic"
-
-$run_qemu
+/scripts/vm/run_vm.sh "$attach_default_virtio_blk"
 
 echo "VM stopped"


### PR DESCRIPTION
There were 2 different ways to run the virtual machine for the integration tests and recipes. This patch gets rid of one of them and uses `scripts/vm/run_vm.sh` to run the vm for the integration tests.