### PR TITLE
Improve storage unit tests to run on CI

### DIFF
--- a/build/storage/tests/ut/host-target/test_run_grpc_server.py
+++ b/build/storage/tests/ut/host-target/test_run_grpc_server.py
@@ -12,14 +12,27 @@ from unittest.mock import patch
 from host_target_grpc_server import run_grpc_server
 from host_target_grpc_server import HostTargetService
 import host_target_pb2_grpc
+import sys
+
+
+class HiddenPrints:
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, "w")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self._original_stdout
 
 
 class RunGrpcServer(unittest.TestCase):
     def test_fail_on_invalid_address_to_listen_to(self):
-        self.assertNotEqual(run_grpc_server("Invalid ip addr", 1010), 0)
+        with HiddenPrints():
+            self.assertNotEqual(run_grpc_server("Invalid ip addr", 1010), 0)
 
     def test_fail_on_invalid_port_to_listen_to(self):
-        self.assertNotEqual(run_grpc_server("0.0.0.0", "Invalid port"), 0)
+        with HiddenPrints():
+            self.assertNotEqual(run_grpc_server("0.0.0.0", "Invalid port"), 0)
 
     def test_success_on_keyboard_interrupt_exception(self):
         server_mock = unittest.mock.Mock()

--- a/build/storage/tests/ut/run.sh
+++ b/build/storage/tests/ut/run.sh
@@ -16,10 +16,11 @@ ut_container="ipdk-unit-tests"
 "${scripts_dir}"/build_container.sh "${ut_container}"
 args=(-e "DEBUG=${DEBUG}")
 if [[ "${1}" == dev ]] ; then
+    args+=(-t)
     args+=(--entrypoint "/bin/bash")
     args+=(-v "${current_script_dir}/proxy-container:/proxy-container/tests")
     args+=(-v "${proxy_src_dir}:/proxy-container/src")
     args+=(-v "${current_script_dir}/host-target:/host-target/tests")
     args+=(-v "${host_target_src_dir}:/host-target/src")
 fi
-docker run -it "${args[@]}" "${ut_container}"
+docker run -i "${args[@]}" "${ut_container}"

--- a/build/storage/tests/ut/run_all_unit_tests.sh
+++ b/build/storage/tests/ut/run_all_unit_tests.sh
@@ -4,7 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-[ "$DEBUG" == 'true' ] && set -x
+if [ "$DEBUG" == 'true' ]; then
+    set -x
+    export GRPC_VERBOSITY=ERROR
+else
+    export GRPC_VERBOSITY=NONE
+fi
 ls -l /host-target/tests
 
 result=0


### PR DESCRIPTION
jenkins does not provide TTY input device. Based on that, we should avoid allocation of pseudo-tty devices for our unit-test container.
Also in this patch some puzzling grpc error logs are suppressed