### PR TITLE
Update docker installation guideline for storage.

### DIFF
--- a/build/storage/recipes/environment_setup.md
+++ b/build/storage/recipes/environment_setup.md
@@ -44,13 +44,12 @@ $ sudo apt install wget
 ```
 
 ### docker
-```
-$ sudo dnf install docker
-```
-or
-```
-$ sudo apt install docker
-```
+Docker 21.10.10 or greater is required.
+
+Installation guideline for [Fedora](https://docs.docker.com/engine/install/fedora/).
+
+Installation guideline for [Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
+
 **Note:**
 Make sure that required proxy settings are configured for docker.
 Please, refer to [this](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)


### PR DESCRIPTION
The New base image(fedora:36) uses glibc >= 2.34 which relies on
clone3(2) sys call. Docker <= 20.10.9 is not able to serve that
sys call properly.
Setup the required docker version to 21.10.10 in the storage
recipes to avoid this error.