### PR TITLE
Add ability to run storage containers as daemons

### DIFF
--- a/build/storage/recipes/environment_setup.md
+++ b/build/storage/recipes/environment_setup.md
@@ -130,7 +130,7 @@ Finally vm console will be opened.
 login:password pair for the vm is `root:root`.
 Run `host-target` container within the vm console
 ```
-$ run_host_target_container.sh &
+$ AS_DAEMON=true run_host_target_container.sh
 ```
 
 4. Prepare environment to send commands to the storage containers.

--- a/build/storage/scripts/run_container.sh
+++ b/build/storage/scripts/run_container.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[ "$DEBUG" == 'true' ] && set -x
+
+declare https_proxy
+declare http_proxy
+declare no_proxy
+
+scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+if [[ -n "${SPDK_CONFIG_FILE}" ]] ; then
+    SPDK_CONFIG_FILE=$(realpath "${SPDK_CONFIG_FILE}")
+    ARGS+=("-v" "${SPDK_CONFIG_FILE}:/config")
+fi
+
+if [ "$ALLOCATE_HUGEPAGES" == "true" ] ; then
+    bash "${scripts_dir}"/allocate_hugepages.sh
+    ARGS+=("-v" "/dev/hugepages:/dev/hugepages")
+fi
+
+if [ "$BUILD_IMAGE" == "true" ] ; then
+    bash "${scripts_dir}"/build_container.sh "$IMAGE_NAME"
+fi
+
+docker run \
+    -it \
+    --privileged \
+    "${ARGS[@]}" \
+    -e DEBUG="$DEBUG" \
+    -e HTTPS_PROXY="$https_proxy" \
+    -e HTTP_PROXY="$http_proxy" \
+    -e NO_PROXY="$no_proxy" \
+    --network host \
+    "$IMAGE_NAME"

--- a/build/storage/scripts/run_container.sh
+++ b/build/storage/scripts/run_container.sh
@@ -26,6 +26,10 @@ if [ "$BUILD_IMAGE" == "true" ] ; then
     bash "${scripts_dir}"/build_container.sh "$IMAGE_NAME"
 fi
 
+if [ "$AS_DAEMON" == "true" ] ; then
+    ARGS+=("-d")
+fi
+
 docker run \
     -it \
     --privileged \

--- a/build/storage/scripts/run_host_target_container.sh
+++ b/build/storage/scripts/run_host_target_container.sh
@@ -6,9 +6,6 @@
 
 [ "$DEBUG" == 'true' ] && set -x
 
-declare https_proxy
-declare http_proxy
-declare no_proxy
 IP_ADDR="${IP_ADDR:-"0.0.0.0"}"
 PORT="${PORT:-50051}"
 
@@ -40,18 +37,11 @@ if [[ $(docker images --filter=reference='host-target' -q) == "" ]]; then
     bash "${scripts_dir}"/build_container.sh host-target
 fi
 
-docker_run="docker run \
-    -it \
-    --privileged \
-    -e IP_ADDR=${IP_ADDR} \
-    -e PORT=${PORT} \
-    -e DEBUG=${DEBUG} \
-    -e HTTPS_PROXY=${https_proxy} \
-    -e HTTP_PROXY=${http_proxy} \
-    -e NO_PROXY=${no_proxy} \
-    --network host \
-    -v /dev:/dev \
-    host-target"
-$docker_run
+IMAGE_NAME="host-target"
+ARGS=()
+ARGS+=("-v" "/dev:/dev")
+ARGS+=("-e" "IP_ADDR=${IP_ADDR}")
+ARGS+=("-e" "PORT=${PORT}")
 
-
+# shellcheck source=./scripts/run_container.sh
+source "${scripts_dir}/run_container.sh"

--- a/build/storage/scripts/run_storage_target_container.sh
+++ b/build/storage/scripts/run_storage_target_container.sh
@@ -6,9 +6,6 @@
 
 [ "$DEBUG" == 'true' ] && set -x
 
-declare https_proxy
-declare http_proxy
-declare no_proxy
 SPDK_CONFIG_FILE="${SPDK_CONFIG_FILE:-}"
 SPDK_IP_ADDR="${SPDK_IP_ADDR:-"0.0.0.0"}"
 SPDK_PORT="${SPDK_PORT:-5260}"
@@ -37,27 +34,12 @@ function check_all_variables_are_set() {
 
 check_all_variables_are_set
 
-bash "${scripts_dir}"/build_container.sh storage-target
-bash "${scripts_dir}"/allocate_hugepages.sh
+ALLOCATE_HUGEPAGES="true"
+BUILD_IMAGE="true"
+IMAGE_NAME="storage-target"
+ARGS=()
+ARGS+=("-e" "SPDK_IP_ADDR=${SPDK_IP_ADDR}")
+ARGS+=("-e" "SPDK_PORT=${SPDK_PORT}")
 
-config_file_option=
-if [[ -n "${SPDK_CONFIG_FILE}" ]]; then
-    SPDK_CONFIG_FILE=$(realpath "${SPDK_CONFIG_FILE}")
-    config_file_option="-v ${SPDK_CONFIG_FILE}:/config"
-fi
-
-docker_run="docker run \
-    -it \
-    --privileged \
-    -v /dev/hugepages:/dev/hugepages \
-    ${config_file_option} \
-    -e SPDK_IP_ADDR=${SPDK_IP_ADDR} \
-    -e SPDK_PORT=${SPDK_PORT} \
-    -e DEBUG=${DEBUG} \
-    -e HTTPS_PROXY=${https_proxy} \
-    -e HTTP_PROXY=${http_proxy} \
-    -e NO_PROXY=${no_proxy} \
-    --network host \
-    storage-target"
-
-$docker_run
+# shellcheck source=./scripts/run_container.sh
+source "${scripts_dir}/run_container.sh"

--- a/build/storage/scripts/vm/prepare_vm.sh
+++ b/build/storage/scripts/vm/prepare_vm.sh
@@ -40,6 +40,7 @@ releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
         run_customize+=(--install "dnf-plugins-core,docker-ce,docker-ce-cli,containerd.io")
         run_customize+=(--copy-in "${path_to_place_vm_file}/host-target.tar:/")
         run_customize+=(--copy-in "${scripts_dir}/run_host_target_container.sh:/usr/local/bin")
+        run_customize+=(--copy-in "${scripts_dir}/run_container.sh:/usr/local/bin")
         run_customize+=(--run-command 'systemctl enable docker.service')
         run_customize+=(--run-command 'service docker start')
         run_customize+=(--firstboot-command 'docker load --input /host-target.tar')


### PR DESCRIPTION
This patch allows to run any of 3 storage containers in detached mode, if `AS_DAEMON` env variable is set to `true`

Also, this patch is a good opportunity to start refactoring the code which is responsible for running the containers in recipes.
Here some duplication is moved into a common `run_container.sh` file.