### PR TITLE
Add host-target customization capability.

### DIFF
--- a/build/storage/.gitignore
+++ b/build/storage/.gitignore
@@ -2,4 +2,6 @@
 __pycache__
 
 *.swp
+core/host-target/customizations/*
+!core/host-target/customizations/README.md
 

--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -131,6 +131,9 @@ COPY core/host-target/host_target.proto /host_target.proto
 RUN python -m grpc_tools.protoc -I/ --python_out=. --grpc_python_out=/ \
     /host_target.proto
 
+ENV CUSTOMIZATION_DIR_IN_CONTAINER=/customizations
+COPY core/host-target/customizations $CUSTOMIZATION_DIR_IN_CONTAINER
+
 ENTRYPOINT [ "/init" ]
 
 ################################################################################
@@ -150,6 +153,7 @@ COPY --from=host-target fio_runner.py /host-target/src/
 COPY --from=host-target pci_devices.py /host-target/src/
 COPY --from=host-target device_exerciser_kvm.py /host-target/src/
 COPY --from=host-target device_exerciser_if.py /host-target/src/
+COPY --from=host-target device_exerciser_customization.py /host-target/src/
 COPY --from=host-target host_target_main.py /host-target/src/
 COPY --from=host-target host_target_grpc_server.py /host-target/src/
 COPY --from=host-target host_target_*pb2.py /host-target/generated/

--- a/build/storage/core/host-target/customizations/README.md
+++ b/build/storage/core/host-target/customizations/README.md
@@ -1,0 +1,60 @@
+# How to add customization to run fio traffic
+If a customized device exerciser is needed on host-target, the required steps
+should be applied:
+1. Create a class inheriting `DeviceExerciserIf` defined in
+`device_exerciser_if.py` file. Within that class, any behavior can be applied
+to run traffic. The file should be placed into a separate directory within
+`customizations` directory. For example:
+```
+# customizations/target/custom_device_exerciser.py
+import device_exerciser_if
+
+class Exerciser(device_exerciser_if.DeviceExerciserIf):
+    def run_fio(self, device_handle, fio_args):
+        return 'ok'
+```
+
+2. Create a file with a single function with the following python signature
+`def make_device_exerciser() -> DeviceExerciserIf:` This function should create
+an instance of a class created on step 1. Additionally, in this file we need to
+add to `PYTHONPATH` the directory where this file is located.
+For example:
+```
+# customizations/make_custom_device_exerciser.py
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(SCRIPT_DIR)
+
+import target.custom_device_exerciser
+
+def make_device_exerciser():
+    return target.custom_device_exerciser.Exerciser()
+```
+
+After those steps, the overall structure might look like this:
+```
+.
+└── customizations
+    ├── target
+    │   └── custom_device_exerciser.py
+    └── make_custom_device_exerciser.py
+```
+
+At this stage there are the following options to add the created customization
+to the 'host-target` container.
+1. Add the customization at build time:
+a. Make sure `host-target` image is not created.
+b. Place the customization content into the directory with this README
+file.
+c. Run `scripts/run_host_target_container.sh` script to build `host-target` with
+provided customization.
+Also, this customization is included in any commands which perform
+`host-target` builds e.g. `scripts/run_vm.sh` or the integration tests run.
+
+2. Add the customization at container start:
+Run `CUSTOMIZATION_DIR=<path_to_customizations> scripts/run_host_target_container.sh`
+script.
+`CUSTOMIZATION_DIR` can be any directory within the filesystem with appropriate
+permissions but not the directory with this README.

--- a/build/storage/core/host-target/device_exerciser_customization.py
+++ b/build/storage/core/host-target/device_exerciser_customization.py
@@ -1,0 +1,86 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import logging
+import os
+import pathlib
+from os import listdir
+from os.path import isfile, join
+from types import ModuleType
+from typing import Callable
+from device_exerciser_if import DeviceExerciserIf
+from importlib.machinery import SourceFileLoader
+
+
+MAKE_DEVICE_EXERCISER_FUNCTION_NAME = "make_device_exerciser"
+
+
+class GetCustomizationError(RuntimeError):
+    pass
+
+
+def _py_files_in_dir_exist(dir: str) -> bool:
+    return len(_get_all_py_files_in_dir(dir)) != 0
+
+
+def _get_all_py_files_in_dir(dir: str) -> list[str]:
+    return [f for f in listdir(dir) if isfile(join(dir, f)) and f.endswith(".py")]
+
+
+def _load_module(module_path: str) -> ModuleType:
+    module_name = pathlib.Path(module_path).stem
+    return SourceFileLoader(module_name, module_path).load_module()
+
+
+def _find_make_device_exerciser_in_module(module: ModuleType) -> Callable:
+    exerciser = getattr(module, MAKE_DEVICE_EXERCISER_FUNCTION_NAME, None)
+    if callable(exerciser):
+        logging.warning(f"Found non-callable {MAKE_DEVICE_EXERCISER_FUNCTION_NAME}")
+        return exerciser
+    else:
+        return None
+
+
+def _find_all_make_device_exercisers_in_dir(dir: str) -> list[Callable]:
+    make_device_exercisers = []
+    py_files = _get_all_py_files_in_dir(dir)
+    for py_file in py_files:
+        module = _load_module(join(dir, py_file))
+        device_exerciser = _find_make_device_exerciser_in_module(module)
+        if device_exerciser:
+            make_device_exercisers.append(device_exerciser)
+    return make_device_exercisers
+
+
+def find_make_custom_device_exerciser(customization_dir: str) -> DeviceExerciserIf:
+    if not customization_dir:
+        logging.info("Customization dir is not set")
+        return None
+    if not os.path.isdir(customization_dir):
+        raise GetCustomizationError(
+            "Customization directory '" + str(customization_dir) + "' is not directory"
+        )
+
+    if _py_files_in_dir_exist(customization_dir):
+        make_device_exercisers = _find_all_make_device_exercisers_in_dir(
+            customization_dir
+        )
+
+        if len(make_device_exercisers) > 1:
+            raise GetCustomizationError(
+                "Function to create device exerciser exists "
+                + str(make_device_exercisers)
+                + " in more than one module in '"
+                + customization_dir
+                + "'"
+            )
+        if len(make_device_exercisers) == 0:
+            raise GetCustomizationError(
+                "No function to create customized device exerciser is found in dir '"
+                + customization_dir
+                + "'"
+            )
+        return make_device_exercisers[0]
+    else:
+        return None

--- a/build/storage/core/host-target/host_target_main.py
+++ b/build/storage/core/host-target/host_target_main.py
@@ -20,6 +20,12 @@ def parse_arguments():
     parser.add_argument(
         "--port", type=int, default=50051, help="port number the server listens to"
     )
+    parser.add_argument(
+        "--customization-dir",
+        type=str,
+        default=None,
+        help="directory with customized device exerciser",
+    )
 
     args = parser.parse_args()
     return args
@@ -30,4 +36,6 @@ if __name__ == "__main__":
 
     args = parse_arguments()
 
-    sys.exit(run_grpc_server(args.ip, args.port))
+    sys.exit(
+        run_grpc_server(args.ip, args.port, customization_dir=args.customization_dir)
+    )

--- a/build/storage/core/host-target/init
+++ b/build/storage/core/host-target/init
@@ -10,4 +10,5 @@
     export HOST_TARGET_LOGLEVEL="DEBUG"
 
 echo "Running host target server for ${IP_ADDR}:${PORT}"
-/host_target_main.py --ip "${IP_ADDR}" --port "${PORT}"
+/host_target_main.py --ip "${IP_ADDR}" --port "${PORT}" \
+    --customization-dir="${CUSTOMIZATION_DIR_IN_CONTAINER}"

--- a/build/storage/core/host-target/pci_devices.py
+++ b/build/storage/core/host-target/pci_devices.py
@@ -34,7 +34,7 @@ class PciAddress:
             self.bus,
             self.device,
             self.function,
-        ) = PciAddress._parse_pci_address(pci_address)
+        ) = PciAddress._parse_pci_address(pci_address.lower())
 
     def get_bus_device_function_address(self) -> str:
         return self.bus + ":" + self.device + "." + self.function
@@ -65,7 +65,7 @@ class FailedPciDeviceDetection(RuntimeError):
 
 def get_virtio_blk_path_by_pci_address(addr: PciAddress) -> str:
     block_directory_pattern = os.path.join(
-        os.path.join("/sys/bus/pci/devices", str(addr)), "virtio*/block"
+        os.path.join("/sys/bus/pci/devices", str(addr).lower()), "virtio*/block"
     )
     block_device_matches = get_all_files_by_pattern(block_directory_pattern)
     if len(block_device_matches) == 0:

--- a/build/storage/scripts/run_host_target_container.sh
+++ b/build/storage/scripts/run_host_target_container.sh
@@ -8,6 +8,9 @@
 
 IP_ADDR="${IP_ADDR:-"0.0.0.0"}"
 PORT="${PORT:-50051}"
+# Set this variable below if it is needed to attach/change
+# customization at container start-up
+CUSTOMIZATION_DIR="${CUSTOMIZATION_DIR:-}"
 
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
@@ -42,6 +45,11 @@ ARGS=()
 ARGS+=("-v" "/dev:/dev")
 ARGS+=("-e" "IP_ADDR=${IP_ADDR}")
 ARGS+=("-e" "PORT=${PORT}")
+if [[ -n "$CUSTOMIZATION_DIR" ]]; then
+    customization_dir_in_container="/customizations"
+    ARGS+=("-v" "$(realpath "$CUSTOMIZATION_DIR"):$customization_dir_in_container")
+    ARGS+=("-e" "CUSTOMIZATION_DIR_IN_CONTAINER=$customization_dir_in_container")
+fi
 
 # shellcheck source=./scripts/run_container.sh
 source "${scripts_dir}/run_container.sh"

--- a/build/storage/tests/it/test-drivers/init.fio
+++ b/build/storage/tests/it/test-drivers/init.fio
@@ -24,28 +24,39 @@ create_and_expose_sybsystem_over_tcp \
 
 wait_until_vm_is_up "${vm_serial}"
 
-ramdrive_size_in_mb=16
-malloc0=$(create_ramdrive_and_attach_as_ns_to_subsystem \
-	"${storage_target_ip}" Malloc0 "${ramdrive_size_in_mb}" "${nqn}")
-virtio_blk0_physical_id=0
-virtio_blk=$(create_virtio_blk "${ipu_storage_container_ip}" "${malloc0}" \
-	"${virtio_blk0_physical_id}" "${virtio_blk_virtual_id}" \
-	"${nqn}" "${storage_target_ip}" "${port_to_expose}")
-
 log_in_with_default_credentials "${vm_serial}"
 
-echo "check attachment"
-is_virtio_blk_attached "${vm_serial}"
-
-echo "Run fio"
 wait_until_host_target_is_up "${vm_serial}"
 
-fio_args="--direct=1 --rw=randrw --bs=4k --ioengine=libaio --iodepth=256 \
-	--runtime=1 --numjobs=4 --time_based --group_reporting \
+function create_virtio_blk_and_test_run_fio() {
+	local virtio_blk_physical_id="${1}"
+	local ramdrive_size_in_mb=16
+	local malloc=""
+	local virtio_blk=""
+	local fio_args="--direct=1 --rw=randrw --bs=4k --ioengine=libaio \
+	--iodepth=256 --runtime=1 --numjobs=4 --time_based --group_reporting \
 	--name=iops-test-job"
-out=$(send_fio_cmd "$traffic_generator_ip" "$HOST_TARGET_SERVICE_PORT" \
+	malloc=$(create_ramdrive_and_attach_as_ns_to_subsystem \
+		"${storage_target_ip}" "Malloc${virtio_blk_physical_id}" \
+		"${ramdrive_size_in_mb}" "${nqn}")
+
+	virtio_blk=$(create_virtio_blk "${ipu_storage_container_ip}" "${malloc}" \
+		"${virtio_blk_physical_id}" "${virtio_blk_virtual_id}" \
+		"${nqn}" "${storage_target_ip}" "${port_to_expose}")
+
+	echo "Run fio over ${virtio_blk}"
+
+	out=$(send_fio_cmd "$traffic_generator_ip" "$HOST_TARGET_SERVICE_PORT" \
 					"$virtio_blk" "$fio_args")
-echo -e "$out"
-echo "${out}" | grep "Disk stats (read/write)"
+	echo -e "${out}"
+	echo "${out}" | grep "Disk stats (read/write)"
+	return "$?"
+}
+
+physical_id=0
+create_virtio_blk_and_test_run_fio "${physical_id}"
+physical_id=10
+create_virtio_blk_and_test_run_fio "${physical_id}"
+
 echo "fio has been executed successfully!"
 exit 0

--- a/build/storage/tests/it/test-drivers/init.scale-out
+++ b/build/storage/tests/it/test-drivers/init.scale-out
@@ -23,7 +23,7 @@ create_and_expose_sybsystem_over_tcp \
 
 ramdrive_size_in_mb=4
 
-echo "Create $NUMBER_OF_DEVICES_TO_ATTACH_IN_SCALE_OUT on storage-target"
+echo "Create $NUMBER_OF_DEVICES_TO_ATTACH_IN_SCALE_OUT disks on storage-target"
 ramdrives=()
 for ((i=0; i < "$NUMBER_OF_DEVICES_TO_ATTACH_IN_SCALE_OUT"; i++))
 do

--- a/build/storage/tests/ut/host-target/test_device_exerciser_customization.py
+++ b/build/storage/tests/ut/host-target/test_device_exerciser_customization.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import shutil
+import unittest
+import tempfile
+import os
+import sys
+
+from device_exerciser_customization import (
+    find_make_custom_device_exerciser,
+    GetCustomizationError,
+    MAKE_DEVICE_EXERCISER_FUNCTION_NAME,
+)
+from device_exerciser_if import DeviceExerciserIf
+from host_target_grpc_server import get_device_exerciser
+from device_exerciser_kvm import DeviceExerciserKvm
+
+
+class FakeDeviceExerciser(DeviceExerciserIf):
+    pass
+
+
+def make_device_exerciser() -> DeviceExerciserIf:
+    return FakeDeviceExerciser()
+
+
+class DeviceExerciserCustomizationTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.file_with_exerciser = os.path.join(
+            self.tempdir, "make_device_exerciser.py"
+        )
+        os.symlink(__file__, self.file_with_exerciser)
+        sys.path.append(self.tempdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_use_customization_if_there_is_appropriate_file(self):
+        self.assertTrue(find_make_custom_device_exerciser(self.tempdir))
+
+    def test_cannot_find_make_custom_device_exerciser_in_empty_dir(self):
+        empty_dir = tempfile.mkdtemp()
+        self.assertFalse(find_make_custom_device_exerciser(empty_dir))
+        os.rmdir(empty_dir)
+
+    def test_cannot_find_make_custom_device_exerciser_in_non_existing_path(self):
+        with self.assertRaises(GetCustomizationError):
+            self.assertFalse(find_make_custom_device_exerciser("/foobar"))
+
+    def test_multiple_modules_creates_device_exerciser(self):
+        another_file_with_exerciser = os.path.join(
+            self.tempdir, "another_make_device_exerciser.py"
+        )
+        os.symlink(__file__, another_file_with_exerciser)
+        with self.assertRaises(GetCustomizationError):
+            find_make_custom_device_exerciser(self.tempdir)
+
+    def test_uses_only_files_with_py_extensions_to_search(self):
+        self.tmp_file_without_py_extension = tempfile.mktemp(dir=self.tempdir)
+        with open(self.tmp_file_without_py_extension, "a") as file:
+            file.write("SomeText\n")
+            file.write("def " + MAKE_DEVICE_EXERCISER_FUNCTION_NAME + "():\n")
+            file.write("    pass\n")
+
+        self.assertTrue(find_make_custom_device_exerciser(self.tempdir))
+
+    def test_other_py_modules_do_not_impact_number_of_exercisers(self):
+        another_empty_py_file = os.path.join(self.tempdir, "empty_file.py")
+        with open(another_empty_py_file, "a") as file:
+            file.write("\n")
+        self.assertTrue(find_make_custom_device_exerciser(self.tempdir))
+
+    def test_return_none_custom_exerciser_with_none_dir(self):
+        self.assertEqual(find_make_custom_device_exerciser(None), None)
+
+    def test_return_none_custom_exerciser_with_empty_dir_name(self):
+        self.assertEqual(find_make_custom_device_exerciser(""), None)
+
+
+class DeviceExerciserCustomizationIsCallableTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.file_with_not_callable_make_exerciser = os.path.join(
+            self.tempdir, "file_with_not_callable_make_exerciser.py"
+        )
+        with open(self.file_with_not_callable_make_exerciser, "a") as file:
+            file.write(f"{MAKE_DEVICE_EXERCISER_FUNCTION_NAME}='non-callable string'\n")
+        sys.path.append(self.tempdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_device_exerciser_should_be_callable(self):
+        with self.assertRaises(GetCustomizationError):
+            find_make_custom_device_exerciser(self.tempdir)
+
+
+class CustomOrDefaultDeviceExerciserCustomizationTests(
+    DeviceExerciserCustomizationTests
+):
+    def test_get_default_device_exerciser_on_none(self):
+        self.assertEqual(type(get_device_exerciser(None)), DeviceExerciserKvm)
+
+    def test_get_default_device_exerciser_on_empty_str_dir(self):
+        self.assertEqual(type(get_device_exerciser("")), DeviceExerciserKvm)
+
+    def test_find_customized_device_exerciser(self):
+        # Since module is loaded dynamically, they have different prefix names
+        # For that purpose we can just compare class names rather than class
+        # names with module prefixes
+        self.assertEqual(
+            type(get_device_exerciser(self.tempdir)).__name__,
+            type(make_device_exerciser()).__name__,
+        )
+
+    def test_found_customized_device_exerciser_returns_none(self):
+        with self.assertRaises(RuntimeError):
+            get_device_exerciser(self.tempdir, lambda unused_path: lambda: None)
+
+    def test_found_customized_device_exerciser_returns_obj_of_wrong_type(self):
+        with self.assertRaises(RuntimeError):
+            get_device_exerciser(self.tempdir, lambda unused_path: lambda: "abc")

--- a/build/storage/tests/ut/host-target/test_device_exerciser_kvm.py
+++ b/build/storage/tests/ut/host-target/test_device_exerciser_kvm.py
@@ -39,9 +39,9 @@ class DeviceExerciserKvmTests(unittest.TestCase):
         self.device_exerciser.run_fio("virtio_blk:sma-32", "unused args")
         self.assertEqual(self.parsed_pci_addr, "0000:02:00.0")
 
-    def test_sma_handle_to_pci_address_in_hex_and_upper_case(self):
+    def test_sma_handle_to_pci_address_in_hex(self):
         self.device_exerciser.run_fio("virtio_blk:sma-60", "unused args")
-        self.assertEqual(self.parsed_pci_addr, "0000:02:1C.0")
+        self.assertEqual(self.parsed_pci_addr, "0000:02:1c.0")
 
     def test_irrelevant_suffix_in_sma_handle(self):
         with self.assertRaises(SmaHandleError):

--- a/build/storage/tests/ut/host-target/test_it_create_customized_device_exerciser.py
+++ b/build/storage/tests/ut/host-target/test_it_create_customized_device_exerciser.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import unittest
+import tempfile
+import shutil
+import os
+
+from device_exerciser_customization import find_make_custom_device_exerciser
+
+
+class DeviceExerciserCustomizationItTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def _create_make_device_exerciser_file(self, path):
+        with open(path, "a") as file:
+            file.write("import sys\n")
+            file.write("import os\n")
+            file.write("SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))\n")
+            file.write("sys.path.append(SCRIPT_DIR)\n")
+            file.write("import target.custom_device_exerciser\n")
+            file.write("def make_device_exerciser():\n")
+            file.write("    return target.custom_device_exerciser.Exerciser()\n")
+
+    def _create_device_exerciser_file(self, path):
+        with open(path, "a") as file:
+            file.write("import device_exerciser_if\n")
+            file.write("class Exerciser(device_exerciser_if.DeviceExerciserIf):\n")
+            file.write("    def run_fio(self, device_handle, fio_args):\n")
+            file.write("        return 'ok'\n")
+
+    def test_deployment_of_customized_device_exerciser(self):
+        os.mkdir(os.path.join(self.tempdir, "target"))
+        make_device_exerciser_file = os.path.join(
+            self.tempdir, "make_custom_device_exerciser.py"
+        )
+        self._create_make_device_exerciser_file(make_device_exerciser_file)
+        device_exerciser_file = os.path.join(
+            self.tempdir, "target/custom_device_exerciser.py"
+        )
+        self._create_device_exerciser_file(device_exerciser_file)
+
+        make_device_exerciser = find_make_custom_device_exerciser(self.tempdir)
+        self.assertTrue(make_device_exerciser)
+        self.assertTrue(make_device_exerciser())
+        self.assertEqual(
+            str(type(make_device_exerciser())),
+            "<class 'target.custom_device_exerciser.Exerciser'>",
+        )

--- a/build/storage/tests/ut/host-target/test_pci_devices.py
+++ b/build/storage/tests/ut/host-target/test_pci_devices.py
@@ -46,14 +46,14 @@ class PciDeviceTests(TestCase):
             PciAddress(None)
 
     def test_corner_bus_value(self):
-        path = "/sys/bus/pci/devices/0000:FF:04.0/virtio0/block/vda"
+        path = "/sys/bus/pci/devices/0000:ff:04.0/virtio0/block/vda"
         self.fs.create_dir(path)
         self.fs.create_file("/dev/vda")
         dev_path = get_virtio_blk_path_by_pci_address(PciAddress("0000:FF:04.0"))
         self.assertEqual(dev_path, "/dev/vda")
 
     def test_corner_device_value(self):
-        path = "/sys/bus/pci/devices/0000:00:1F.0/virtio0/block/vda"
+        path = "/sys/bus/pci/devices/0000:00:1f.0/virtio0/block/vda"
         self.fs.create_dir(path)
         self.fs.create_file("/dev/vda")
         dev_path = get_virtio_blk_path_by_pci_address(PciAddress("0000:00:1F.0"))

--- a/build/storage/tests/ut/host-target/test_run_grpc_server.py
+++ b/build/storage/tests/ut/host-target/test_run_grpc_server.py
@@ -30,11 +30,11 @@ class HiddenPrints:
 class RunGrpcServer(unittest.TestCase):
     def test_fail_on_invalid_address_to_listen_to(self):
         with HiddenPrints():
-            self.assertNotEqual(run_grpc_server("Invalid ip addr", 1010), 0)
+            self.assertNotEqual(run_grpc_server("Invalid ip addr", 1010, None), 0)
 
     def test_fail_on_invalid_port_to_listen_to(self):
         with HiddenPrints():
-            self.assertNotEqual(run_grpc_server("0.0.0.0", "Invalid port"), 0)
+            self.assertNotEqual(run_grpc_server("0.0.0.0", "Invalid port", None), 0)
 
     def test_success_on_keyboard_interrupt_exception(self):
         server_mock = unittest.mock.Mock()
@@ -43,7 +43,7 @@ class RunGrpcServer(unittest.TestCase):
         def server_creator(unused):
             return server_mock
 
-        self.assertEqual(run_grpc_server("Unused", "Unused", server_creator), 0)
+        self.assertEqual(run_grpc_server("Unused", "Unused", None, server_creator), 0)
         self.assertTrue(server_mock.add_insecure_port.was_called)
 
     @patch.object(host_target_pb2_grpc, "add_HostTargetServicer_to_server")
@@ -56,7 +56,7 @@ class RunGrpcServer(unittest.TestCase):
         ip_addr = "ip_addr"
         port = "port"
 
-        self.assertEqual(run_grpc_server(ip_addr, port, server_creator), 0)
+        self.assertEqual(run_grpc_server(ip_addr, port, None, server_creator), 0)
 
         self.assertTrue(server_mock.add_insecure_port.was_called)
         call_args = server_mock.add_insecure_port.call_args.args


### PR DESCRIPTION
IPDK is planned as target-agnostic set of drivers/tools etc.
Based on that we need to provide an ability to run our services with different target platforms. host-target container is one of them and it should be able to detect a disk to run traffic against by means of SPDK SMA opaque handle. For that purpose, ability to run custom device exerciser is added.