### PR TITLE
Use json format for fio args in host-target

### DIFF
--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -150,6 +150,7 @@ RUN python -m pip install grpcio-reflection pyfakefs
 
 COPY tests/ut/host-target /host-target/tests
 COPY --from=host-target fio_runner.py /host-target/src/
+COPY --from=host-target fio_args.py /host-target/src/
 COPY --from=host-target pci_devices.py /host-target/src/
 COPY --from=host-target device_exerciser_kvm.py /host-target/src/
 COPY --from=host-target device_exerciser_if.py /host-target/src/

--- a/build/storage/core/host-target/device_exerciser_customization.py
+++ b/build/storage/core/host-target/device_exerciser_customization.py
@@ -9,6 +9,7 @@ from os import listdir
 from os.path import isfile, join
 from types import ModuleType
 from typing import Callable
+from typing import Optional
 from device_exerciser_if import DeviceExerciserIf
 from importlib.machinery import SourceFileLoader
 
@@ -33,7 +34,7 @@ def _load_module(module_path: str) -> ModuleType:
     return SourceFileLoader(module_name, module_path).load_module()
 
 
-def _find_make_device_exerciser_in_module(module: ModuleType) -> Callable:
+def _find_make_device_exerciser_in_module(module: ModuleType) -> Optional[Callable]:
     exerciser = getattr(module, MAKE_DEVICE_EXERCISER_FUNCTION_NAME, None)
     if callable(exerciser):
         logging.warning(f"Found non-callable {MAKE_DEVICE_EXERCISER_FUNCTION_NAME}")
@@ -53,7 +54,9 @@ def _find_all_make_device_exercisers_in_dir(dir: str) -> list[Callable]:
     return make_device_exercisers
 
 
-def find_make_custom_device_exerciser(customization_dir: str) -> DeviceExerciserIf:
+def find_make_custom_device_exerciser(
+    customization_dir: str,
+) -> Optional[Callable]:
     if not customization_dir:
         logging.info("Customization dir is not set")
         return None

--- a/build/storage/core/host-target/device_exerciser_if.py
+++ b/build/storage/core/host-target/device_exerciser_if.py
@@ -1,10 +1,14 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
+
+from fio_args import FioArgs
+
+
 class DeviceExerciserError(RuntimeError):
     pass
 
 
 class DeviceExerciserIf:
-    def run_fio(self, device_handle: str, fio_args: str) -> str:
+    def run_fio(self, device_handle: str, fio_args: FioArgs) -> str:
         raise NotImplementedError()

--- a/build/storage/core/host-target/device_exerciser_kvm.py
+++ b/build/storage/core/host-target/device_exerciser_kvm.py
@@ -31,10 +31,10 @@ class DeviceExerciserKvm(DeviceExerciserIf):
 
     class _SmaHandle:
         def get_protocol(self) -> str:
-            raise NotImplemented()
+            raise NotImplementedError()
 
         def get_pci_address(self) -> PciAddress:
-            raise NotImplemented
+            raise NotImplementedError()
 
     class _KvmSmaHandle(_SmaHandle):
         def __init__(
@@ -107,7 +107,7 @@ class DeviceExerciserKvm(DeviceExerciserIf):
     def _create_sma_handle_from_str(self, device_handle: str) -> _SmaHandle:
         return self._KvmSmaHandle(device_handle)
 
-    def run_fio(self, device_handle: str, fio_args: str) -> str:
+    def run_fio(self, device_handle: str, fio_args: FioArgs) -> str:
         sma_handle = self._create_sma_handle_from_str(device_handle)
 
         if sma_handle.get_protocol() not in self._device_detectors:

--- a/build/storage/core/host-target/device_exerciser_kvm.py
+++ b/build/storage/core/host-target/device_exerciser_kvm.py
@@ -119,5 +119,5 @@ class DeviceExerciserKvm(DeviceExerciserIf):
             sma_handle.get_pci_address()
         )
 
-        fio_args_with_device = fio_args + " --filename=" + device_path
-        return self._fio_runner(fio_args_with_device)
+        fio_args.add_argument("filename", device_path)
+        return self._fio_runner(fio_args)

--- a/build/storage/core/host-target/fio_args.py
+++ b/build/storage/core/host-target/fio_args.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import json
+import tempfile
+
+
+class FioArgsError(ValueError):
+    pass
+
+
+class FioArgs:
+    class Config:
+        def __init__(self, owner: "FioArgs") -> None:
+            self._owner = owner
+            self._file = None
+            self.file_name = ""
+
+        def __enter__(self):
+            self._file = tempfile.NamedTemporaryFile()
+            self.file_name = self._file.name
+
+            with open(self.file_name, "w") as config:
+                self._dump_owner_to_file(config)
+
+            self._file.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+            self._file.__exit__(exc_type, exc_val, exc_tb)
+
+        def _dump_owner_to_file(self, file: TextIOWrapper) -> None:
+            file.write("[job0]\n")
+            for arg_key in self._owner._fio_args:
+                file.write(arg_key + "=" + str(self._owner._fio_args[arg_key]) + "\n")
+            file.flush()
+
+    def __init__(self, fio_args_str: str) -> None:
+        try:
+            self._fio_args = json.loads(fio_args_str)
+        except (json.JSONDecodeError, TypeError) as err:
+            raise FioArgsError(str(err))
+
+    def add_argument(self, key: str, value: str) -> None:
+        self._fio_args[key] = value
+
+    def create_config_file(self) -> Config:
+        return FioArgs.Config(self)
+
+    def __str__(self) -> str:
+        return json.dumps(self._fio_args)

--- a/build/storage/core/host-target/fio_args.py
+++ b/build/storage/core/host-target/fio_args.py
@@ -4,6 +4,7 @@
 
 import json
 import tempfile
+import typing
 
 
 class FioArgsError(ValueError):
@@ -30,7 +31,7 @@ class FioArgs:
         def __exit__(self, exc_type, exc_val, exc_tb) -> None:
             self._file.__exit__(exc_type, exc_val, exc_tb)
 
-        def _dump_owner_to_file(self, file: TextIOWrapper) -> None:
+        def _dump_owner_to_file(self, file: typing.TextIO) -> None:
             file.write("[job0]\n")
             for arg_key in self._owner._fio_args:
                 file.write(arg_key + "=" + str(self._owner._fio_args[arg_key]) + "\n")

--- a/build/storage/core/host-target/fio_runner.py
+++ b/build/storage/core/host-target/fio_runner.py
@@ -2,25 +2,28 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import subprocess
+import tempfile
+from fio_args import FioArgs
 
 
 class FioExecutionError(RuntimeError):
     pass
 
 
-def run_fio(fio_args: str) -> str:
+def run_fio(fio_args: FioArgs):
     fio_cmd = []
     try:
-        fio_cmd = ["fio"] + fio_args.split()
-        result = subprocess.run(fio_cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            raise FioExecutionError(
-                "fio execution error: '"
-                + str(result.stdout)
-                + "' | '"
-                + str(result.stderr)
-                + "' "
-            )
-        return result.stdout
+        with fio_args.create_config_file() as config:
+            fio_cmd = ["fio", config.file_name]
+            result = subprocess.run(fio_cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                raise FioExecutionError(
+                    "fio execution error: '"
+                    + str(result.stdout)
+                    + "' | '"
+                    + str(result.stderr)
+                    + "' "
+                )
+            return result.stdout
     except AttributeError as ex:
         raise FioExecutionError("Invalid input argument '" + str(fio_args) + "'")

--- a/build/storage/core/host-target/host_target_grpc_server.py
+++ b/build/storage/core/host-target/host_target_grpc_server.py
@@ -13,6 +13,7 @@ from grpc_reflection.v1alpha import reflection
 from device_exerciser_kvm import DeviceExerciserKvm
 from device_exerciser_if import *
 from device_exerciser_customization import find_make_custom_device_exerciser
+from fio_args import FioArgs, FioArgsError
 
 
 class HostTargetService(host_target_pb2_grpc.HostTargetServicer):
@@ -28,7 +29,7 @@ class HostTargetService(host_target_pb2_grpc.HostTargetServicer):
         output = None
         try:
             output = self._device_exerciser.run_fio(
-                request.deviceHandle, request.fioArgs
+                request.deviceHandle, FioArgs(request.fioArgs)
             )
         except BaseException as ex:
             logging.error("Service exception: '" + str(ex) + "'")

--- a/build/storage/tests/it/test-drivers/init.fio
+++ b/build/storage/tests/it/test-drivers/init.fio
@@ -33,9 +33,9 @@ function create_virtio_blk_and_test_run_fio() {
 	local ramdrive_size_in_mb=16
 	local malloc=""
 	local virtio_blk=""
-	local fio_args="--direct=1 --rw=randrw --bs=4k --ioengine=libaio \
-	--iodepth=256 --runtime=1 --numjobs=4 --time_based --group_reporting \
-	--name=iops-test-job"
+	local fio_args="{\"rw\":\"randrw\", \"direct\":1, \"bs\":\"4k\", \
+		\"iodepth\":256, \"ioengine\":\"libaio\", \"runtime\":10, \
+		\"name\":\"iops_test-job\", \"time_based\": 1, \"numjobs\": 4}"
 	malloc=$(create_ramdrive_and_attach_as_ns_to_subsystem \
 		"${storage_target_ip}" "Malloc${virtio_blk_physical_id}" \
 		"${ramdrive_size_in_mb}" "${nqn}")

--- a/build/storage/tests/ut/host-target/test_device_exerciser_customization.py
+++ b/build/storage/tests/ut/host-target/test_device_exerciser_customization.py
@@ -9,6 +9,8 @@ import unittest
 import tempfile
 import os
 import sys
+import logging
+import warnings
 
 from device_exerciser_customization import (
     find_make_custom_device_exerciser,
@@ -30,6 +32,8 @@ def make_device_exerciser() -> DeviceExerciserIf:
 
 class DeviceExerciserCustomizationTests(unittest.TestCase):
     def setUp(self):
+        logging.disable(logging.CRITICAL)
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         self.tempdir = tempfile.mkdtemp()
         self.file_with_exerciser = os.path.join(
             self.tempdir, "make_device_exerciser.py"
@@ -38,6 +42,8 @@ class DeviceExerciserCustomizationTests(unittest.TestCase):
         sys.path.append(self.tempdir)
 
     def tearDown(self):
+        warnings.filterwarnings("default", category=DeprecationWarning)
+        logging.disable(logging.NOTSET)
         shutil.rmtree(self.tempdir)
 
     def test_use_customization_if_there_is_appropriate_file(self):
@@ -84,6 +90,8 @@ class DeviceExerciserCustomizationTests(unittest.TestCase):
 
 class DeviceExerciserCustomizationIsCallableTests(unittest.TestCase):
     def setUp(self):
+        logging.disable(logging.CRITICAL)
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         self.tempdir = tempfile.mkdtemp()
         self.file_with_not_callable_make_exerciser = os.path.join(
             self.tempdir, "file_with_not_callable_make_exerciser.py"
@@ -93,6 +101,8 @@ class DeviceExerciserCustomizationIsCallableTests(unittest.TestCase):
         sys.path.append(self.tempdir)
 
     def tearDown(self):
+        warnings.filterwarnings("default", category=DeprecationWarning)
+        logging.disable(logging.NOTSET)
         shutil.rmtree(self.tempdir)
 
     def test_device_exerciser_should_be_callable(self):

--- a/build/storage/tests/ut/host-target/test_device_exerciser_kvm.py
+++ b/build/storage/tests/ut/host-target/test_device_exerciser_kvm.py
@@ -8,6 +8,7 @@ import unittest
 
 from device_exerciser_kvm import *
 from device_exerciser_if import *
+from fio_args import FioArgs
 
 
 class DeviceExerciserKvmTests(unittest.TestCase):
@@ -27,59 +28,61 @@ class DeviceExerciserKvmTests(unittest.TestCase):
             {self.protocol_name: stub_get_virtio_blk_path},
             self.stub_run_fio,
         )
+        self.fio_args = FioArgs('{ "some": "arg" }')
 
     def tearDown(self):
         self.parsed_pci_addr = ""
 
     def test_sma_handle_parsed_to_pci_address(self):
-        self.device_exerciser.run_fio("virtio_blk:sma-0", "unused args")
+        self.device_exerciser.run_fio("virtio_blk:sma-0", self.fio_args)
         self.assertEqual(self.parsed_pci_addr, "0000:01:00.0")
 
     def test_sma_handle_to_pci_on_another_bus(self):
-        self.device_exerciser.run_fio("virtio_blk:sma-32", "unused args")
+        self.device_exerciser.run_fio("virtio_blk:sma-32", self.fio_args)
         self.assertEqual(self.parsed_pci_addr, "0000:02:00.0")
 
     def test_sma_handle_to_pci_address_in_hex(self):
-        self.device_exerciser.run_fio("virtio_blk:sma-60", "unused args")
+        self.device_exerciser.run_fio("virtio_blk:sma-60", self.fio_args)
         self.assertEqual(self.parsed_pci_addr, "0000:02:1c.0")
 
     def test_irrelevant_suffix_in_sma_handle(self):
         with self.assertRaises(SmaHandleError):
             self.device_exerciser.run_fio(
-                "virtio_blk:sma-0:some_irrelevant_suffix", "unused args"
+                "virtio_blk:sma-0:some_irrelevant_suffix", self.fio_args
             )
 
     def test_pass_empty_string_as_sma_handle(self):
         with self.assertRaises(SmaHandleError):
-            self.device_exerciser.run_fio("", "unused args")
+            self.device_exerciser.run_fio("", self.fio_args)
 
     def test_pass_none_as_sma_handle(self):
         with self.assertRaises(SmaHandleError):
-            self.device_exerciser.run_fio(None, "unused args")
+            self.device_exerciser.run_fio(None, self.fio_args)
 
     def test_invalid_separator_for_protocol_in_sma_handle(self):
         with self.assertRaises(SmaHandleError):
-            self.device_exerciser.run_fio("virtio_blk;sma-0", "unused args")
+            self.device_exerciser.run_fio("virtio_blk;sma-0", self.fio_args)
 
     def test_physical_id_is_not_integer_in_sma_handle(self):
         with self.assertRaises(SmaHandleError):
-            self.device_exerciser.run_fio("virtio_blk:sma-a", "unused args")
+            self.device_exerciser.run_fio("virtio_blk:sma-a", self.fio_args)
 
     def test_invalid_separator_for_physical_id_in_sma_handle(self):
         with self.assertRaises(SmaHandleError):
-            self.device_exerciser.run_fio("virtio_blk:sma_0", "unused args")
+            self.device_exerciser.run_fio("virtio_blk:sma_0", self.fio_args)
 
     def test_physical_id_exceeds_number_of_buses_in_sma_handle(self):
         with self.assertRaises(SmaHandleError):
-            self.device_exerciser.run_fio("virtio_blk:sma-4294967295", "unused args")
+            self.device_exerciser.run_fio("virtio_blk:sma-4294967295", self.fio_args)
 
     def test_invalid_protocol(self):
         with self.assertRaises(DeviceExerciserError):
-            self.device_exerciser.run_fio("non-existing-protocol:sma-0", "unused")
+            self.device_exerciser.run_fio("non-existing-protocol:sma-0", self.fio_args)
 
     def test_successful_fio_run(self):
-        fio_args = "unused args"
-        out = self.device_exerciser.run_fio("virtio_blk:sma-0", fio_args)
+        out = self.device_exerciser.run_fio("virtio_blk:sma-0", self.fio_args)
         self.assertEqual(out, self.stub_fio_output)
-        self.assertTrue(self.stub_device_path in self.stub_run_fio.call_args.args[0])
-        self.assertTrue(fio_args in self.stub_run_fio.call_args.args[0])
+        self.assertTrue(
+            self.stub_device_path in str(self.stub_run_fio.call_args.args[0])
+        )
+        self.assertTrue(str(self.fio_args) in str(self.stub_run_fio.call_args.args[0]))

--- a/build/storage/tests/ut/host-target/test_fio_args.py
+++ b/build/storage/tests/ut/host-target/test_fio_args.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import unittest
+import os
+
+from fio_args import *
+
+
+class FioArgsTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_create_config_file(self):
+        fio_args = FioArgs('{"name":"test"}')
+        with fio_args.create_config_file() as config:
+            self.assertTrue(config.file_name)
+            self.assertTrue(os.path.isfile(config.file_name))
+
+    def test_config_file_has_right_content(self):
+        fio_args = FioArgs('{"name":"test", "size":"4MB", "filename":"test"}')
+        with fio_args.create_config_file() as config:
+            with open(config.file_name) as file:
+                config_content = file.read()
+                self.assertTrue("name=test\n" in config_content)
+                self.assertTrue("size=4MB\n" in config_content)
+                self.assertTrue("filename=test\n" in config_content)
+
+    def test_config_file_is_removed_after_with(self):
+        fio_args = FioArgs('{"name":"test"}')
+        config_file_name = ""
+        with fio_args.create_config_file() as config:
+            config_file_name = config.file_name
+        self.assertFalse(os.path.isfile(config_file_name))
+
+    def test_raise_on_invalid_json_input(self):
+        with self.assertRaises(FioArgsError) as ex:
+            FioArgs('{"name":no-quotation-mark", "size":"4MB", "filename":"test"}')
+
+    def test_raise_on_empty_input(self):
+        with self.assertRaises(FioArgsError):
+            FioArgs("")
+
+    def test_raise_on_none_input(self):
+        with self.assertRaises(FioArgsError):
+            FioArgs(None)
+
+    def test_add_argument_to_existing_args(self):
+        fio_args = FioArgs('{"name":"test"}')
+        fio_args.add_argument("foo", "bar")
+        with fio_args.create_config_file() as config:
+            with open(config.file_name) as file:
+                config_content = file.read()
+                self.assertTrue("name=test\n" in config_content)
+                self.assertTrue("foo=bar\n" in config_content)
+
+    def test_string_representation_in_json_form(self):
+        fio_args_str = '{"name": "test"}'
+        fio_args = FioArgs(fio_args_str)
+        self.assertEqual(str(fio_args), fio_args_str)

--- a/build/storage/tests/ut/host-target/test_fio_runner.py
+++ b/build/storage/tests/ut/host-target/test_fio_runner.py
@@ -9,12 +9,13 @@ import os
 
 from fio_runner import run_fio
 from fio_runner import FioExecutionError
+from fio_args import FioArgs
 
 
 class FioRunner(unittest.TestCase):
     def setUp(self):
         self.fio_file = "test"
-        self.fio_args = "--name=test --size=4MB --filename=test"
+        self.fio_args = FioArgs('{"name":"test", "size":"4MB", "filename":"test"}')
 
     def tearDown(self):
         if os.path.exists(self.fio_file):
@@ -39,15 +40,3 @@ class FioRunner(unittest.TestCase):
     def test_none_fio_arg(self):
         with self.assertRaises(FioExecutionError) as ex:
             run_fio(None)
-
-    def test_pass_invalid_arg_type(self):
-        with self.assertRaises(FioExecutionError) as ex:
-            run_fio(123)
-
-    def test_no_concat_cmds_allowed(self):
-        with self.assertRaises(FioExecutionError) as ex:
-            run_fio("ls -l && ls")
-        with self.assertRaises(FioExecutionError) as ex:
-            run_fio("ls -l || ls")
-        with self.assertRaises(FioExecutionError) as ex:
-            run_fio("ls -l ; ls")

--- a/build/storage/tests/ut/host-target/test_host_target_grpc_server.py
+++ b/build/storage/tests/ut/host-target/test_host_target_grpc_server.py
@@ -26,8 +26,8 @@ class HostTargetServerTests(unittest.TestCase):
         exerciser_kvm.run_fio = unittest.mock.Mock(return_value="output")
         server = HostTargetService(exerciser_kvm)
         request = host_target_pb2.RunFioRequest()
-        request.deviceHandle = "unused"
-        request.fioArgs = "unused"
+        request.deviceHandle = "virtio_blk:sma-0"
+        request.fioArgs = "{}"
         context = unittest.mock.MagicMock()
 
         reply = server.RunFio(request, context)
@@ -42,8 +42,8 @@ class HostTargetServerTests(unittest.TestCase):
         exerciser_kvm.run_fio = unittest.mock.Mock(side_effect=BaseException())
         server = HostTargetService(exerciser_kvm)
         request = host_target_pb2.RunFioRequest()
-        request.deviceHandle = "unused"
-        request.fioArgs = "unused"
+        request.deviceHandle = "virtio_blk:sma-0"
+        request.fioArgs = "{}"
         context = unittest.mock.MagicMock()
 
         server.RunFio(request, context)

--- a/build/storage/tests/ut/host-target/test_it_create_customized_device_exerciser.py
+++ b/build/storage/tests/ut/host-target/test_it_create_customized_device_exerciser.py
@@ -8,15 +8,21 @@ import unittest
 import tempfile
 import shutil
 import os
+import logging
+import warnings
 
 from device_exerciser_customization import find_make_custom_device_exerciser
 
 
 class DeviceExerciserCustomizationItTests(unittest.TestCase):
     def setUp(self):
+        logging.disable(logging.CRITICAL)
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
+        warnings.filterwarnings("default", category=DeprecationWarning)
+        logging.disable(logging.NOTSET)
         shutil.rmtree(self.tempdir)
 
     def _create_make_device_exerciser_file(self, path):


### PR DESCRIPTION
Currently fio arguments are provided as command line strings.
This can be inconvenient for parsing/modification and this patch accepts incoming fio args to host-traget service in json format.