### PR TITLE
shellcheck: Fix shellcheck

### DIFF
--- a/build/networking/scripts/build_p4sde.sh
+++ b/build/networking/scripts/build_p4sde.sh
@@ -29,7 +29,7 @@ mkdir "$1/p4-sde" && cd "$1/p4-sde" || exit
 echo "Exporting Environment Variables....."
 export SDE="${PWD}"
 export SDE_INSTALL="$SDE/install"
-mkdir $SDE_INSTALL || exit
+mkdir "$SDE_INSTALL" || exit
 
 #...Package Config Path...#
 if [ "${OS}" = "Ubuntu" ]  || [ "${VER}" = "20.04" ] ; then

--- a/build/scripts/ipdk-lib.sh
+++ b/build/scripts/ipdk-lib.sh
@@ -49,7 +49,7 @@ function check_buildx() {
 		return 1
 	fi
 
-	distro=$(cat /etc/os-release | grep "^ID=" | cut -d= -f2)
+	distro=$(grep "^ID=" < /etc/os-release | cut -d= -f2)
 	if [[ "$distro" = "fedora" ]]; then
 		if ! systemctl is-active --quiet systemd-binfmt ; then
 			echo "Service systemd-binfmt is not started"

--- a/build/scripts/run-shellcheck.sh
+++ b/build/scripts/run-shellcheck.sh
@@ -3,7 +3,7 @@
 # Simple script to find all bash scripts and run shellcheck on them
 #
 
-set -eu
+set -euxo pipefail
 
 is_bash() {
     [[ $1 == *.sh ]] && return 0
@@ -20,6 +20,13 @@ is_excluded_from_check() {
 
 while IFS= read -r -d $'' file; do
     if ! is_excluded_from_check "$file" && is_bash "$file" ; then
-        shellcheck -x -W0 -s bash "$file" || continue
+        shellcheck -x -W0 -s bash "$file"
+        rc=$?
+        if [ "${rc}" -eq 0 ]
+        then
+            continue
+        else
+            exit 1
+        fi
     fi
 done < <(find . -type f \! -path "./.git/*" -print0)

--- a/build/storage/scripts/build_container.sh
+++ b/build/storage/scripts/build_container.sh
@@ -9,7 +9,7 @@ set -e
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 root_dir="${script_dir}/.."
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${script_dir}"/spdk_version.sh
 "${script_dir}"/prepare_to_build.sh
 

--- a/build/storage/scripts/run_host_target_container.sh
+++ b/build/storage/scripts/run_host_target_container.sh
@@ -40,7 +40,7 @@ if [[ $(docker images --filter=reference='host-target' -q) == "" ]]; then
     bash "${scripts_dir}"/build_container.sh host-target
 fi
 
-#IMAGE_NAME="host-target"
+export IMAGE_NAME="host-target"
 ARGS=()
 ARGS+=("-v" "/dev:/dev")
 ARGS+=("-e" "IP_ADDR=${IP_ADDR}")

--- a/build/storage/scripts/run_host_target_container.sh
+++ b/build/storage/scripts/run_host_target_container.sh
@@ -40,7 +40,7 @@ if [[ $(docker images --filter=reference='host-target' -q) == "" ]]; then
     bash "${scripts_dir}"/build_container.sh host-target
 fi
 
-IMAGE_NAME="host-target"
+#IMAGE_NAME="host-target"
 ARGS=()
 ARGS+=("-v" "/dev:/dev")
 ARGS+=("-e" "IP_ADDR=${IP_ADDR}")
@@ -52,4 +52,5 @@ if [[ -n "$CUSTOMIZATION_DIR" ]]; then
 fi
 
 # shellcheck source=./scripts/run_container.sh
+# shellcheck disable=SC1091,SC1090
 source "${scripts_dir}/run_container.sh"

--- a/build/storage/scripts/run_ipu_storage_container.sh
+++ b/build/storage/scripts/run_ipu_storage_container.sh
@@ -8,9 +8,9 @@
 [ "$DEBUG" == 'true' ] && set -x
 
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "$scripts_dir/vm/vm_default_variables.sh"
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "$scripts_dir/sma_config_file.sh"
 
 SHARED_VOLUME=${SHARED_VOLUME:-$(realpath .)}
@@ -57,12 +57,13 @@ function cleanup() {
 }
 trap 'cleanup' EXIT
 
-ALLOCATE_HUGEPAGES="true"
-BUILD_IMAGE="true"
-IMAGE_NAME="ipu-storage-container"
+#ALLOCATE_HUGEPAGES="true"
+#BUILD_IMAGE="true"
+#IMAGE_NAME="ipu-storage-container"
 ARGS=()
 ARGS+=("-v" "${SHARED_VOLUME}:/${SHARED_VOLUME}")
 ARGS+=("-v" "${tmp_sma_config_file}:/sma_config.yml")
 
 # shellcheck source=./scripts/run_container.sh
+# shellcheck disable=SC1091,SC1090
 source "${scripts_dir}/run_container.sh"

--- a/build/storage/scripts/run_ipu_storage_container.sh
+++ b/build/storage/scripts/run_ipu_storage_container.sh
@@ -57,9 +57,9 @@ function cleanup() {
 }
 trap 'cleanup' EXIT
 
-#ALLOCATE_HUGEPAGES="true"
-#BUILD_IMAGE="true"
-#IMAGE_NAME="ipu-storage-container"
+export ALLOCATE_HUGEPAGES="true"
+export BUILD_IMAGE="true"
+export IMAGE_NAME="ipu-storage-container"
 ARGS=()
 ARGS+=("-v" "${SHARED_VOLUME}:/${SHARED_VOLUME}")
 ARGS+=("-v" "${tmp_sma_config_file}:/sma_config.yml")

--- a/build/storage/scripts/run_storage_target_container.sh
+++ b/build/storage/scripts/run_storage_target_container.sh
@@ -34,12 +34,13 @@ function check_all_variables_are_set() {
 
 check_all_variables_are_set
 
-ALLOCATE_HUGEPAGES="true"
-BUILD_IMAGE="true"
-IMAGE_NAME="storage-target"
+#ALLOCATE_HUGEPAGES="true"
+#BUILD_IMAGE="true"
+#IMAGE_NAME="storage-target"
 ARGS=()
 ARGS+=("-e" "SPDK_IP_ADDR=${SPDK_IP_ADDR}")
 ARGS+=("-e" "SPDK_PORT=${SPDK_PORT}")
 
 # shellcheck source=./scripts/run_container.sh
+# shellcheck disable=SC1091,SC1090
 source "${scripts_dir}/run_container.sh"

--- a/build/storage/scripts/run_storage_target_container.sh
+++ b/build/storage/scripts/run_storage_target_container.sh
@@ -34,9 +34,9 @@ function check_all_variables_are_set() {
 
 check_all_variables_are_set
 
-#ALLOCATE_HUGEPAGES="true"
-#BUILD_IMAGE="true"
-#IMAGE_NAME="storage-target"
+export ALLOCATE_HUGEPAGES="true"
+export BUILD_IMAGE="true"
+export IMAGE_NAME="storage-target"
 ARGS=()
 ARGS+=("-e" "SPDK_IP_ADDR=${SPDK_IP_ADDR}")
 ARGS+=("-e" "SPDK_PORT=${SPDK_PORT}")

--- a/build/storage/scripts/sma_config_file.sh
+++ b/build/storage/scripts/sma_config_file.sh
@@ -7,7 +7,7 @@
 [ "$DEBUG" == 'true' ] && set -x
 
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "$scripts_dir/vm/vm_default_variables.sh"
 
 function create_sma_config_file() {

--- a/build/storage/scripts/vm/run_vm.sh
+++ b/build/storage/scripts/vm/run_vm.sh
@@ -7,7 +7,7 @@
 [ "$DEBUG" == 'true' ] && set -x
 
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/..
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "$scripts_dir"/vm/vm_default_variables.sh
 
 SHARED_VOLUME=${SHARED_VOLUME:-.}

--- a/build/storage/tests/it/run.sh
+++ b/build/storage/tests/it/run.sh
@@ -10,7 +10,7 @@ set -e
 current_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 root_dir="${current_script_dir}"/../..
 scripts_dir="${root_dir}"/scripts
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${scripts_dir}"/spdk_version.sh
 bash "${scripts_dir}"/prepare_to_build.sh
 declare https_proxy

--- a/build/storage/tests/it/test-drivers/init.fio
+++ b/build/storage/tests/it/test-drivers/init.fio
@@ -15,7 +15,7 @@ declare ipu_storage_container_ip
 declare virtio_blk_virtual_id
 declare port_to_expose
 declare traffic_generator_ip
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${current_script_dir}"/test-helpers
 
 wait_until_port_on_ip_addr_open "${storage_target_ip}" "${DEFAULT_SPDK_PORT}"

--- a/build/storage/tests/it/test-drivers/init.hot-plug
+++ b/build/storage/tests/it/test-drivers/init.hot-plug
@@ -14,7 +14,7 @@ declare storage_target_ip
 declare ipu_storage_container_ip
 declare virtio_blk_virtual_id
 declare port_to_expose
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${current_script_dir}"/test-helpers
 
 wait_until_port_on_ip_addr_open "${storage_target_ip}" "${DEFAULT_SPDK_PORT}"

--- a/build/storage/tests/it/test-drivers/init.scale-out
+++ b/build/storage/tests/it/test-drivers/init.scale-out
@@ -14,7 +14,7 @@ declare storage_target_ip
 declare ipu_storage_container_ip
 declare virtio_blk_virtual_id
 declare port_to_expose
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${current_script_dir}"/test-helpers
 
 wait_until_port_on_ip_addr_open "${storage_target_ip}" "${DEFAULT_SPDK_PORT}"

--- a/build/storage/tests/it/test-drivers/test-helpers
+++ b/build/storage/tests/it/test-drivers/test-helpers
@@ -10,9 +10,9 @@ current_script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && p
 root_dir=${current_script_dir}/../..
 scripts_dir=${root_dir}/scripts
 
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${scripts_dir}"/socket.sh
-# shellcheck disable=SC1091
+# shellcheck disable=SC1091,SC1090
 source "${scripts_dir}"/disk_infrastructure.sh
 
 function wait_until_vm_is_up() {


### PR DESCRIPTION
This allows shellcheck to fail correctly on errors, something it was not
doing previously.

Fixed in opi-poc here [1].

[1] https://github.com/opiproject/opi-poc/pull/114

Signed-off-by: Kyle Mestery <mestery@mestery.com>