### PR TITLE
Feat rewrite disk infrastructure to python

### DIFF
--- a/build/storage/scripts/disk_infrastructure.py
+++ b/build/storage/scripts/disk_infrastructure.py
@@ -1,0 +1,180 @@
+import base64
+import json
+import logging
+import re
+import socket
+import subprocess
+import time
+import uuid
+
+logging.root.setLevel(logging.CRITICAL)
+
+
+def get_number_of_virtio_blk(socket: str) -> int:
+    cmd = 'lsblk --output "NAME,VENDOR,SUBSYSTEMS"'
+    out = subprocess.run(
+        f'source scripts/socket.sh; send_command_over_unix_socket "{socket}" "{cmd}" 1',
+        capture_output=True,
+        check=True,
+        shell=True,
+        text=True,
+    ).stdout
+    number_of_virtio_blk_devices = len(re.findall("block:virtio:pci", out))
+    return number_of_virtio_blk_devices
+
+
+def is_virtio_blk_attached(socket: str) -> int:
+    if get_number_of_virtio_blk(socket) == 0:
+        logging.error("virtio-blk is not found")
+        return 1
+    logging.info("virtio-blk is found")
+    return 0
+
+
+def is_virtio_blk_not_attached(socket: str) -> int:
+    if is_virtio_blk_attached(socket):
+        return 0
+    return 1
+
+
+def check_number_of_virtio_blk_devices(
+    vm_serial: str, expected_number_of_devices: int
+) -> int:
+    number_of_devices = get_number_of_virtio_blk(vm_serial)
+    if number_of_devices != expected_number_of_devices:
+        logging.error(
+            f"Required number of devices '{expected_number_of_devices}' does "
+            f"not equal to actual number of devices '{number_of_devices}'"
+        )
+        return 1
+    else:
+        logging.info(f"Number of attached virtio-blk devices is '{number_of_devices}'")
+        return 0
+
+
+def create_and_expose_subsystem_over_tcp(
+    ip_addr: str, nqn: str, port_to_expose: int, storage_target_port: int
+) -> None:
+    subprocess.run(
+        f"rpc.py -s {ip_addr} -p {storage_target_port} "
+        f"nvmf_create_subsystem {nqn} -s SPDK00000000000001 -a -m 1024",
+        check=True,
+        shell=True,
+    )
+    subprocess.run(
+        f"rpc.py -s {ip_addr} -p {storage_target_port} nvmf_create_transport -t TCP -u 8192",
+        check=True,
+        shell=True,
+    )
+    subprocess.run(
+        f"rpc.py -s {ip_addr} -p {storage_target_port} nvmf_subsystem_add_listener "
+        f"{nqn} -t TCP -f IPv4 -a {ip_addr} -s {port_to_expose}",
+        check=True,
+        shell=True,
+    )
+
+
+def create_ramdrive_and_attach_as_ns_to_subsystem(
+    ip_addr: str,
+    ramdrive_name: str,
+    number_of_512b_blocks: int,
+    nqn: str,
+    storage_target_port: int,
+) -> str:
+    subprocess.run(
+        f"rpc.py -s {ip_addr} -p {storage_target_port} bdev_malloc_create "
+        f"-b {ramdrive_name} {number_of_512b_blocks} 512",
+        check=True,
+        shell=True,
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        f"rpc.py -s {ip_addr} -p {storage_target_port} "
+        f"nvmf_subsystem_add_ns {nqn} {ramdrive_name}",
+        check=True,
+        shell=True,
+    )
+    data = subprocess.run(
+        f"rpc.py -s {ip_addr} bdev_get_bdevs",
+        capture_output=True,
+        check=True,
+        shell=True,
+        text=True,
+    ).stdout
+    dict_list = json.loads(data)
+    device_uuid = [d["uuid"] for d in dict_list if d["name"] == ramdrive_name][0]
+    return device_uuid
+
+
+def uuid2base64(device_uuid: str) -> str:
+    return base64.b64encode(uuid.UUID(device_uuid).bytes).decode()
+
+
+def create_virtio_blk_without_disk_check(
+    ipu_storage_container_ip: str,
+    volume_id: str,
+    physical_id: str,
+    virtual_id: str,
+    hostnqn: str,
+    traddr: str,
+    trsvcid: str,
+    sma_port: int,
+) -> str:
+    data = {
+        "method": "CreateDevice",
+        "params": {
+            "volume": {
+                "volume_id": uuid2base64(volume_id),
+                "nvmf": {
+                    "hostnqn": hostnqn,
+                    "discovery": {
+                        "discovery_endpoints": [
+                            {"trtype": "tcp", "traddr": traddr, "trsvcid": trsvcid}
+                        ]
+                    },
+                },
+            },
+            "virtio_blk": {"physical_id": physical_id, "virtual_id": virtual_id},
+        },
+    }
+    data = subprocess.run(
+        f"sma-client.py --address {ipu_storage_container_ip} --port {sma_port}",
+        capture_output=True,
+        check=True,
+        input=json.dumps(data),
+        shell=True,
+        text=True,
+    ).stdout
+    device_handle = json.loads(data)["handle"]
+    return device_handle
+
+
+def delete_virtio_blk(
+    ipu_storage_container_ip: str, device_handle: str, sma_port: int
+) -> int:
+    data = {"method": "DeleteDevice", "params": {"handle": device_handle}}
+    return subprocess.run(
+        f"sma-client.py --address {ipu_storage_container_ip} --port {sma_port}",
+        check=True,
+        input=json.dumps(data),
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        text=True,
+    ).returncode
+
+
+def wait_for_virtio_blk_in_os(timeout: float) -> None:
+    time.sleep(timeout)
+
+
+def create_virtio_blk(*args, **kwargs) -> str:
+    disk_handle = create_virtio_blk_without_disk_check(*args, **kwargs)
+    wait_for_virtio_blk_in_os(2)
+    return disk_handle
+
+
+def is_port_open(ip_addr: str, port: int, timeout: float) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        return s.connect_ex((ip_addr, port))

--- a/build/storage/scripts/disk_infrastructure.sh
+++ b/build/storage/scripts/disk_infrastructure.sh
@@ -10,195 +10,156 @@ export DEFAULT_NVME_PORT=4420
 export MAX_NUMBER_OF_NAMESPACES_ON_COTROLLER=1024
 
 function get_number_of_virtio_blk() {
-	cmd="lsblk --output \"NAME,VENDOR,SUBSYSTEMS\""
-	out=$( send_command_over_unix_socket "${1}" "${cmd}" 1 )
-	number_of_virio_blk_devices=$(echo "${out}" | grep -c "block:virtio:pci")
-	echo "${number_of_virio_blk_devices}"
+    python3 <<- EOF
+from scripts import disk_infrastructure
+
+print(disk_infrastructure.get_number_of_virtio_blk(socket="${1}"))
+EOF
 }
 
 function is_virtio_blk_attached() {
-	number_of_virio_blk_devices=$(get_number_of_virtio_blk "${1}")
+    return $(python3 <<- EOF
+from scripts import disk_infrastructure
 
-	if [[ "${number_of_virio_blk_devices}" == 0 ]]; then
-		echo "virtio-blk is not found"
-		return 1
-	else
-		echo "virtio-blk is found"
-		return 0
-	fi
+print(disk_infrastructure.is_virtio_blk_attached(socket="${1}"))
+EOF
+)
 }
 
 function is_virtio_blk_not_attached() {
-	if is_virtio_blk_attached "${1}"; then
-		return 1
-	fi
+    return $(python3 <<- EOF
+from scripts import disk_infrastructure
 
-	return 0
+print(disk_infrastructure.is_virtio_blk_not_attached(socket="${1}"))
+EOF
+)
 }
 
 function check_number_of_virtio_blk_devices() {
-	vm_serial="${1}"
-	expected_number_of_devices="${2}"
-	number_of_devices=$(get_number_of_virtio_blk "${vm_serial}")
-	if [[ "${number_of_devices}" != "${expected_number_of_devices}" ]]; then
-		echo "Required number of devices '${expected_number_of_devices}' does"
-		echo "not equal to actual number of devices '${number_of_devices}'"
-		return 1
-	else
-		echo "Number of attached virtio-blk devices is '${number_of_devices}'"
-		return 0
-	fi
+    return $(python3 <<- EOF
+from scripts import disk_infrastructure
+
+print(
+    disk_infrastructure.check_number_of_virtio_blk_devices(
+        vm_serial="${1}",
+	    expected_number_of_devices=int("${2}")
+    )
+)
+EOF
+)
 }
 
 function create_and_expose_sybsystem_over_tcp() {
-	ip_addr="${1}"
-	nqn="${2}"
-	port_to_expose="${3:-"$DEFAULT_NVME_PORT"}"
-	storage_target_port="${4:-"$DEFAULT_SPDK_PORT"}"
+    python3 <<- EOF
+from scripts import disk_infrastructure
 
-	rpc.py -s "${ip_addr}" -p "$storage_target_port" \
-		nvmf_create_subsystem "${nqn}" \
-		-s SPDK00000000000001 -a \
-		-m "$MAX_NUMBER_OF_NAMESPACES_ON_COTROLLER"
-	rpc.py -s "${ip_addr}" -p "$storage_target_port" \
-		nvmf_create_transport -t TCP -u 8192
-	rpc.py -s "${ip_addr}" -p "$storage_target_port" \
-		nvmf_subsystem_add_listener "${nqn}" -t TCP \
-		-f IPv4 -a "${ip_addr}" -s "${port_to_expose}"
+disk_infrastructure.create_and_expose_subsystem_over_tcp(
+    ip_addr="${1}",
+    nqn="${2}",
+    port_to_expose=int("${3:-"$DEFAULT_NVME_PORT"}"),
+    storage_target_port=int("${4:-"$DEFAULT_SPDK_PORT"}")
+)
+EOF
 }
 
 function create_ramdrive_and_attach_as_ns_to_subsystem() {
-	ip_addr="${1}"
-	ramdrive_name="${2}"
-	ramdrive_size_in_mb="${3}"
-	nqn="${4}"
-	storage_target_port="${5:-"$DEFAULT_SPDK_PORT"}"
+    python3 <<- EOF
+from scripts import disk_infrastructure
 
-	rpc.py -s "${ip_addr}" -p "${storage_target_port}" \
-		bdev_malloc_create -b "${ramdrive_name}" \
-		"${ramdrive_size_in_mb}" 512 &> /dev/null
-	rpc.py -s "${ip_addr}" -p "${storage_target_port}" \
-		nvmf_subsystem_add_ns "${nqn}" "${ramdrive_name}"
-	device_uuid=$(rpc.py -s "${ip_addr}" bdev_get_bdevs | \
-		jq -r ".[] | select(.name==\"${ramdrive_name}\") | .uuid")
-	echo "$device_uuid"
+print(
+    disk_infrastructure.create_ramdrive_and_attach_as_ns_to_subsystem(
+        ip_addr="${1}",
+        ramdrive_name="${2}",
+	    number_of_512b_blocks=int("${3}"),
+        nqn="${4}",
+	    storage_target_port=int("${5:-"$DEFAULT_SPDK_PORT"}")
+    )
+)
+EOF
 }
 
 function uuid2base64() {
-	python3 <<- EOF
-		import base64, uuid
-		print(base64.b64encode(uuid.UUID("$1").bytes).decode())
-	EOF
+    python3 <<- EOF
+from scripts import disk_infrastructure
+
+print(disk_infrastructure.uuid2base64(device_uuid="$1"))
+EOF
 }
 
 function wait_for_virtio_blk_in_os() {
-	local virtio_blk_handle="$1"
-	local wait_for_virtio_blk_sec="$2"
+    python3 <<- EOF
+from scripts import disk_infrastructure
 
-	echo "$virtio_blk_handle" > /dev/null
-	# placeholder function for now
-	sleep "$wait_for_virtio_blk_sec"
-	return 0
-}
-
-function _create_virtio_blk() {
-	ipu_storage_container_ip="${1}"
-	sma_port="${2}"
-	volume_id="${3}"
-	physical_id="${4}"
-	virtual_id="${5}"
-	hostnqn="${6}"
-	traddr="${7}"
-	trsvcid="${8}"
-
-	sma-client.py --address="$ipu_storage_container_ip" --port="$sma_port" <<- EOF
-	{
-		"method": "CreateDevice",
-		"params": {
-			"volume": {
-				"volume_id": "$(uuid2base64 "${volume_id}")",
-				"nvmf": {
-					"hostnqn": "${hostnqn}",
-					"discovery": {
-						"discovery_endpoints": [
-							{
-								"trtype": "tcp",
-								"traddr": "${traddr}",
-								"trsvcid": "${trsvcid}"
-							}
-						]
-					}
-				}
-			},
-			"virtio_blk": {
-				"physical_id": ${physical_id},
-				"virtual_id": ${virtual_id}
-			}
-		}
-	}
-	EOF
+disk_infrastructure.wait_for_virtio_blk_in_os(
+    timeout=float("${2}")
+)
+EOF
 }
 
 function create_virtio_blk() {
-	local disk_handle=""
-	disk_handle=$(create_virtio_blk_without_disk_check "$@")
-	local wait_for_virtio_blk_sec=2
-	wait_for_virtio_blk_in_os "$disk_handle" "$wait_for_virtio_blk_sec"
+    python3 <<- EOF
+from scripts import disk_infrastructure
 
-	echo "$disk_handle"
+print(
+    disk_infrastructure.create_virtio_blk(
+        ipu_storage_container_ip="${1}",
+        volume_id="${2}",
+        physical_id="${3}",
+        virtual_id="${4}",
+        hostnqn="${5}",
+        traddr="${6}",
+        trsvcid="${7:-"$DEFAULT_NVME_PORT"}",
+	    sma_port=int("${8:-"$DEFAULT_SMA_PORT"}")
+    )
+)       
+EOF
 }
 
 function create_virtio_blk_without_disk_check() {
-	ipu_storage_container_ip="${1}"
-	volume_id="${2}"
-	physical_id="${3}"
-	virtual_id="${4}"
-	hostnqn="${5}"
-	traddr="${6}"
-	trsvcid="${7:-"$DEFAULT_NVME_PORT"}"
-	sma_port="${8:-"$DEFAULT_SMA_PORT"}"
+    python3 <<- EOF
+from scripts import disk_infrastructure
 
-	device_handle=$(_create_virtio_blk "$ipu_storage_container_ip" "$sma_port" \
-					"$volume_id" "$physical_id" "$virtual_id" "$hostnqn" \
-					"$traddr" "$trsvcid" | jq -r '.handle')
-	echo "$device_handle"
+print(
+    disk_infrastructure.create_virtio_blk_without_disk_check(
+        ipu_storage_container_ip="${1}",
+        volume_id="${2}",
+        physical_id="${3}",
+        virtual_id="${4}",
+        hostnqn="${5}",
+        traddr="${6}",
+        trsvcid="${7:-"$DEFAULT_NVME_PORT"}",
+	    sma_port=int("${8:-"$DEFAULT_SMA_PORT"}")
+    )
+)
+EOF
 }
 
 function delete_virtio_blk() {
-	ipu_storage_container_ip="${1}"
-	device_handle="${2}"
-	sma_port="${3:-"$DEFAULT_SMA_PORT"}"
+    return $(python3 <<- EOF
+from scripts import disk_infrastructure
 
-	sma-client.py --address="$ipu_storage_container_ip" --port="$sma_port" <<- EOF
-	{
-		"method": "DeleteDevice",
-		"params": {
-			"handle": "${device_handle}"
-		}
-	}
-	EOF
-	return $?
-}
-
-function is_port_on_ip_addr_open() {
-	local ip_addr="$1"
-	local port="$2"
-	timeout 1 bash -c "cat < /dev/null > /dev/tcp/${ip_addr}/${port}" &> /dev/null
-	return $?
+print(
+    disk_infrastructure.delete_virtio_blk(
+        ipu_storage_container_ip="${1}",
+        device_handle="${2}",
+	    sma_port=int("${3:-"$DEFAULT_SMA_PORT"}")
+    )
+)
+EOF
+)
 }
 
 function wait_until_port_on_ip_addr_open() {
-	local ip_addr="$1"
-	local port="$2"
-	local wait_for_sec="${3:-5}"
-	local wait_counter=0
+    return $(python3 <<- EOF
+from scripts import disk_infrastructure
 
-	while [ "${wait_counter}" -le "${wait_for_sec}" ] ; do
-		if is_port_on_ip_addr_open "$ip_addr" "$port"; then
-			return 0
-		fi
-		sleep 1
-		wait_counter=$(( wait_counter + 1 ))
-	done
-	return 1
+print(
+    disk_infrastructure.is_port_open(
+        ip_addr="$1",
+	    port=int("$2"),
+	    timeout=float("${3:-5}")
+    )
+)
+EOF
+)
 }


### PR DESCRIPTION
Previously, all functions used to execute operations described in recipes or used in tests were written in shell. This approach was error-prone and more reliable language is used. Rewritten functions were placed in a new file - disk_infrastructure.py - and formatted with black. An __init__.py file was created inside of scripts directory to make it a package and easily import python functions.
Reworked functionality:
- Subsystem creation
- Ramdrive creation and its attachment to subsystem
- Virtio-blk creation
- Virtio-blk deletion
- Checking if a port is open
- Getting/Checking number of Virtio-blk devices
- Checking if a Virtio-blk is attached or not
    
Signed-off-by: rilnickx rafalx.ilnicki@intel.com