### PR TITLE
dependabot: Update dependabot docker config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,34 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/build/networking_ebpf"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/networking"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/storage"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/storage/tests/it/test-drivers"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/storage/tests/it/traffic-generator"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/storage/spdk/docker/spdk-app"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/storage/spdk/docker/traffic-generator"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/build/storage/spdk/docker/build_base"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This moves to ensuring each directory containing a Dockerfile has a path
element in the dependabot configuration.

Signed-off-by: Kyle Mestery <mestery@mestery.com>