### PR TITLE
linters: Add hadolint Dockerfile linter

### DIFF
--- a/.github/workflows/linters.md
+++ b/.github/workflows/linters.md
@@ -1,4 +1,4 @@
-name: MarkdownLint
+name: Linters
 
 on:
   push:
@@ -16,3 +16,12 @@ jobs:
       - uses: avto-dev/markdown-lint@v1.5.0
         with:
           args: './*.md'
+
+  docker-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hadolint/hadolint-action@v2.0.0
+        with:
+          recursive: true
+          ignore: DL3041


### PR DESCRIPTION
This adds the hadolint [1] Dockerfile linter to the IPDK CI.

[1] https://github.com/hadolint/hadolint

Signed-off-by: Kyle Mestery <mestery@mestery.com>