### PR TITLE
Install numactl package and specific protobuf version

### DIFF
--- a/build/networking/Dockerfile.fedora
+++ b/build/networking/Dockerfile.fedora
@@ -49,6 +49,7 @@ RUN dnf -y update && \
     curl \
     connect-proxy \
     coreutils \
+    numactl-devel \
     which && \
     dnf -y clean all && \
     rm -rf /var/cache/yum
@@ -57,7 +58,7 @@ RUN dnf -y update && \
 RUN python -m pip install --upgrade pip && \
     python -m pip install grpcio && \
     python -m pip install ovspy && \
-    python -m pip install protobuf && \
+    python -m pip install protobuf==3.20.1 && \
     python -m pip install p4runtime && \
     pip3 install pyelftools && \
     pip3 install scapy && \

--- a/build/networking/Dockerfile.ubuntu
+++ b/build/networking/Dockerfile.ubuntu
@@ -56,6 +56,7 @@ RUN apt-get install -y apt-utils \
     connect-proxy \
     coreutils \
     vim \
+    numactl \
     sudo && \
     if [ "$BASE_IMG" = "ubuntu:18.04" ] ; then \
        apt-get -y install python-pip; \
@@ -68,7 +69,7 @@ RUN apt-get install -y apt-utils \
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir grpcio && \
     python3 -m pip install --no-cache-dir ovspy \
-    protobuf \
+    protobuf==3.20.1 \
     p4runtime \
     pyelftools \
     scapy \


### PR DESCRIPTION
This patch introduces installing numactl package to
avoid issues with memory initialization when OVS is started.
Per "https://developers.google.com/protocol-buffers/docs/news/2022-05-06",
protobuf version is updated to 3.20.1 to avoid issues with
ovs-p4ctl utility

Title: Install numactl package and specific protobuf version
Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>