### PR TITLE
ipdk: Update p4 modules to latest SHA

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -23,7 +23,7 @@ through dedicated HW over HW-agnostic interfaces.
 
 #### Feature support
 
-* Linux Networking support(L2 Forwarding,VXLAN,ECMP,Routing,Connection tracking)
+* Linux Networking support(L2 Forwarding,VXLAN,ECMP, and Routing)
 * Hotplug support for vhost-user ports
 * OpenConfig GNMI CLI support for TAP ports and physical link ports
 * Port Configuration dump

--- a/build/networking/Dockerfile.fedora
+++ b/build/networking/Dockerfile.fedora
@@ -73,5 +73,6 @@ COPY ./scripts scripts
 COPY ./examples /root/examples
 COPY ./start_p4ovs.sh /root/start_p4ovs.sh 
 COPY ./run_ovs_cmds /root/run_ovs_cmds
+COPY ./patches /root/patches
 RUN  /root/start_p4ovs.sh /root && \
      /root/scripts/run_cleanup.sh /root ${KEEP_SOURCE_CODE}

--- a/build/networking/Dockerfile.ubuntu
+++ b/build/networking/Dockerfile.ubuntu
@@ -85,5 +85,6 @@ COPY ./scripts scripts
 COPY ./examples /root/examples
 COPY ./start_p4ovs.sh /root/start_p4ovs.sh
 COPY ./run_ovs_cmds /root/run_ovs_cmds
+COPY ./patches /root/patches
 RUN  /root/start_p4ovs.sh /root && \
      /root/scripts/run_cleanup.sh /root ${KEEP_SOURCE_CODE}

--- a/build/networking/patches/ipdk_p4c_001.patch
+++ b/build/networking/patches/ipdk_p4c_001.patch
@@ -1,0 +1,53 @@
+diff --git a/backends/dpdk/dpdkAsmOpt.cpp b/backends/dpdk/dpdkAsmOpt.cpp
+index 16eeb7b86..b91014767 100644
+--- a/backends/dpdk/dpdkAsmOpt.cpp
++++ b/backends/dpdk/dpdkAsmOpt.cpp
+@@ -364,14 +364,17 @@ CopyPropagationAndElimination::copyPropAndDeadCodeElim(
+         } else if (auto jne = stmt->to<IR::DpdkJmpNotEqualStatement>()) {
+             instr.push_back(new IR::DpdkJmpNotEqualStatement(jne->label,
+                         replaceIfCopy(jne->src1, false), replaceIfCopy(jne->src2)));
+-       } else if (auto l = stmt->to<IR::DpdkLearnStatement>()) {
++        } else if (auto l = stmt->to<IR::DpdkLearnStatement>()) {
+             instr.push_back(new IR::DpdkLearnStatement(l->action,
+                         replaceIfCopy(l->timeout, false), replaceIfCopy(l->argument, false)));
+-       } else if (auto m = stmt->to<IR::DpdkMeterExecuteStatement>()) {
++        } else if (auto m = stmt->to<IR::DpdkMeterExecuteStatement>()) {
+             instr.push_back(new IR::DpdkMeterExecuteStatement(m->meter,
+                     replaceIfCopy(m->index), replaceIfCopy(m->length),
+                     replaceIfCopy(m->color_in), replaceIfCopy(m->color_out)));
+-       } else {
++        } else if (auto c = stmt->to<IR::DpdkCounterCountStatement>()) {
++            instr.push_back(new IR::DpdkCounterCountStatement(c->counter,
++                            replaceIfCopy(c->index), replaceIfCopy(c->incr)));
++        } else {
+             instr.push_back(stmt);
+         }
+     }
+diff --git a/p4include/pna.p4 b/p4include/pna.p4
+index afc08ece2..15659e248 100644
+--- a/p4include/pna.p4
++++ b/p4include/pna.p4
+@@ -373,7 +373,7 @@ enum PNA_CounterType_t {
+ @noWarn("unused")
+ extern Counter<W, S> {
+   Counter(bit<32> n_counters, PNA_CounterType_t type);
+-  void count(in S index);
++  void count(in S index, @optional in bit<32> increment);
+ }
+ // END:Counter_extern
+ 
+@@ -405,12 +405,12 @@ extern Meter<S> {
+   // Use this method call to perform a color aware meter update (see
+   // RFC 2698). The color of the packet before the method call was
+   // made is specified by the color parameter.
+-  PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color);
++  PNA_MeterColor_t execute(in S index, in PNA_MeterColor_t color, @optional in bit<32> pkt_len);
+ 
+   // Use this method call to perform a color blind meter update (see
+   // RFC 2698).  It may be implemented via a call to execute(index,
+   // MeterColor_t.GREEN), which has the same behavior.
+-  PNA_MeterColor_t execute(in S index);
++  PNA_MeterColor_t execute(in S index, @optional in bit<32> pkt_len);
+ }
+ // END:Meter_extern
+ 

--- a/build/networking/scripts/build_p4c.sh
+++ b/build/networking/scripts/build_p4c.sh
@@ -14,7 +14,7 @@ then
 fi
 
 #SHA on top which P4C is validated
-P4C_SHA=45e5d70245ef8ec691d0d758e1c91a087ecdeb45
+P4C_SHA=bad00d940a7913d6df671dc4947409982d5f7a84
 
 WORKDIR=$1
 cd "$WORKDIR"
@@ -29,9 +29,15 @@ get_num_cores
 echo "Number of Parallel threads used: $NUM_THREADS ..."
 echo ""
 
-git clone https://github.com/p4lang/p4c.git --recursive P4C
+git clone https://github.com/p4lang/p4c.git P4C
 cd P4C
 git checkout $P4C_SHA
+git submodule update --init --recursive
+# Patch for supporting PNA indirect counters
+# Currently changes are under PNA architecture review
+# Patch will be removed once changes are official and
+# available in open source p4lang/p4c
+git apply "$WORKDIR/patches/ipdk_p4c_001.patch"
 mkdir build && cd build
 cmake  ..
 make $NUM_THREADS

--- a/build/networking/scripts/build_p4sde.sh
+++ b/build/networking/scripts/build_p4sde.sh
@@ -60,8 +60,7 @@ if [ -d "p4-driver" ]; then rm -Rf p4-driver; fi
 echo "Compiling p4-driver"
 git clone https://github.com/p4lang/p4-dpdk-target.git p4-driver
 pushd "$SDE/p4-driver"
-#Note: Below SHA needs to be updated when TDI code is open-sourced
-git checkout 780b3dfa205815e87f4580383cc37bfa30187f7c
+git checkout v22.07
 git submodule update --init --recursive
 popd
 
@@ -75,7 +74,7 @@ popd
 
 cd "$SDE/p4-driver" || exit
 ./autogen.sh
-./configure --prefix="$SDE_INSTALL"
+./configure --prefix="$SDE_INSTALL" --with-generic-flags=yes
 make clean
 make "$NUM_THREADS"
 make "$NUM_THREADS" install

--- a/build/networking/scripts/get_p4ovs_repo.sh
+++ b/build/networking/scripts/get_p4ovs_repo.sh
@@ -18,6 +18,6 @@ echo "Cloning P4-OVS repo"
 cd "$WORKDIR" || exit
 git clone https://github.com/ipdk-io/ovs.git -b ovs-with-p4 P4-OVS
 pushd "$WORKDIR/P4-OVS" || exit
-git checkout abfbcb94bd899580fdf96950939c0910d489894d
+git checkout v22.07
 git submodule update --init --recursive
 popd || exit

--- a/build/networking/scripts/host_install.sh
+++ b/build/networking/scripts/host_install.sh
@@ -90,12 +90,13 @@ then
         connect-proxy \
         coreutils \
         sudo \
+        numactl \
         make
 
         pip install --upgrade pip && \
         pip install grpcio \
             ovspy \
-            protobuf \
+            protobuf==3.20.1 \
             p4runtime \
             pyelftools \
             scapy \
@@ -140,13 +141,14 @@ else
     curl \
     connect-proxy \
     coreutils \
+    numactl-devel \
     which
 
     # Installing all PYTHON packages
     python -m pip install --upgrade pip && \
     python -m pip install grpcio && \
     python -m pip install ovspy && \
-    python -m pip install protobuf && \
+    python -m pip install protobuf==3.20.1 && \
     python -m pip install p4runtime && \
     pip3 install pyelftools && \
     pip3 install scapy && \
@@ -156,6 +158,7 @@ fi
 pushd /root || exit
 cp -r /git/ipdk/build/networking/scripts .
 cp -r /git/ipdk/build/networking/examples .
+cp -r /git/ipdk/build/networking/patches .
 cp /git/ipdk/build/networking/start_p4ovs.sh start_p4ovs.sh
 cp /git/ipdk/build/networking/run_ovs_cmds run_ovs_cmds
 popd


### PR DESCRIPTION
Build script changes to update the P4 OvS, P4 SDE and
P4C modules to ipdk release 22.07 tags or SHA.
Also additional changes to apply P4C patch on top of
open source latest SHA.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>