### PR TITLE
IPDK: Fix build issues in Ubuntu 18.04

### DIFF
--- a/build/networking/Dockerfile.ubuntu
+++ b/build/networking/Dockerfile.ubuntu
@@ -69,14 +69,18 @@ RUN apt-get install -y apt-utils \
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir grpcio && \
     python3 -m pip install --no-cache-dir ovspy \
-    protobuf==3.20.1 \
     p4runtime \
     pyelftools \
     scapy \
     six \
     cmake>=3.15.0 \
     meson==0.59.4 \
-    ninja>=1.8.2
+    ninja>=1.8.2 && \
+    if [ "$BASE_IMG" = "ubuntu:18.04" ] ; then \
+       python3 -m pip install --no-cache-dir protobuf==3.19.4; \
+    else \
+       python3 -m pip install --no-cache-dir protobuf==3.20.1; \
+    fi
 
 FROM base AS p4-ovs-container
 ARG KEEP_SOURCE_CODE


### PR DESCRIPTION
Protobuf version 3.20.1 is not supported in Ubuntu 18.04, hence
build was failing.
Made a conditional check to the Dockerfile.ubuntu from (PR #215),
which will pull protobuf different versions of protobuf for Ubuntu 18.04 and 20.04

This PR fixes issue: #223

Signed-off-by: n-sandeep <sandeep.nagapattinam@intel.com>