### PR TITLE
Use requirements.txt to install host-target deps.

### DIFF
--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -119,8 +119,10 @@ ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
 
+COPY core/host-target/requirements.txt /
 # hadolint ignore=DL3013
-RUN dnf install -y python fio python3-pip && dnf clean all && python -m pip install --no-cache-dir grpcio grpcio-tools grpcio-reflection
+RUN dnf install -y python fio python3-pip && dnf clean all && \
+    python -m pip install --no-cache-dir -r /requirements.txt
 
 COPY core/host-target/init /init
 COPY core/host-target/*.py /

--- a/build/storage/core/host-target/requirements.txt
+++ b/build/storage/core/host-target/requirements.txt
@@ -1,0 +1,8 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+grpcio
+grpcio-tools
+grpcio-reflection
+


### PR DESCRIPTION
All host-target dependencies should be collected into requirements.txt file since some analyzers use requirements.txt file to perform checks.

Signed-off-by: Artsiom Koltun <artsiom.koltun@intel.com>