### PR TITLE
Add ptf setup tests

### DIFF
--- a/build/storage/ptf_test/README.md
+++ b/build/storage/ptf_test/README.md
@@ -1,0 +1,15 @@
+# Setup
+To prepare the environment setup for testing follow these steps:
+1. Copy `setup.sh` to your home directory and run it. This will clone the required repositories.
+```bash
+. setup.sh
+```
+2. Navigate to the `storage` directory and run integration test to build docker images.
+```bash
+sudo tests/it/run.sh hot-plug
+```
+3. Fill `python_system_tools/data.json` with ip addresses, user name and password.
+4. Run ptf setup tests within `ptf_test` directory.
+```bash
+. run_setup_tests.sh
+```

--- a/build/storage/ptf_test/run_setup_tests.sh
+++ b/build/storage/ptf_test/run_setup_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+test_case_names=(
+  "test_connection"
+  "test_setup"
+  "test_containers_deploy"
+  "test_docker"
+)
+
+path_to_ptf=$(find "$HOME" -name ptf | head -n 1)
+path_to_tests=$(find "$HOME" -name ptf_test | head -n 1)
+
+cd "$path_to_ptf"
+for i in "${test_case_names[@]}"; do
+   sudo ./ptf --test-dir "$path_to_tests"/setup_tests "$i" --pypath /usr/lib/python3.9/ --platform=dummy
+done
+cd "$path_to_tests"

--- a/build/storage/ptf_test/setup.sh
+++ b/build/storage/ptf_test/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+branch='feat-add-ptf-setup-tests'
+git_url='https://github.com/intelfisz/ipdk.git'
+ptf_url='https://github.com/p4lang/ptf.git'
+
+current_dir=$(pwd)
+storage_path="$current_dir/IPDK_workspace/ipdk/build/storage/"
+
+mkdir -p "IPDK_workspace"
+cd "IPDK_workspace" && git clone --branch "$branch" "$git_url"
+cd "$storage_path" && git clone "$ptf_url"
+cd "$storage_path" && git submodule update --init --recursive --force
+cd && mkdir -p "IPDK_workspace/SHARE"

--- a/build/storage/ptf_test/setup_tests/test_connection.py
+++ b/build/storage/ptf_test/setup_tests/test_connection.py
@@ -1,0 +1,63 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append('../')
+
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.containers_deploy import ContainersDeploy
+from ptf import testutils
+from ptf.base_tests import BaseTest
+from python_system_tools.data import ip_address_proxy, ip_address_storage, ip_address_cmd_sender, user_name, password
+
+
+class TestExecute(BaseTest):
+
+    def setUp(self):
+        self.proxy_terminal = ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password, )
+        self.storage_terminal = ExtendedTerminal(address=ip_address_storage, user=user_name, password=password)
+        self.cmd_sender_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+        self.terminals = [self.proxy_terminal, self.storage_terminal, self.cmd_sender_terminal]
+
+    def runTest(self):
+        for terminal in self.terminals:
+            assert terminal.execute("whoami") == (f"{user_name}\n", 0)
+
+    def tearDown(self):
+        pass
+
+
+class TestExecuteAsRoot(BaseTest):
+
+    def setUp(self):
+        self.proxy_terminal = ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password)
+        self.storage_terminal = ExtendedTerminal(address=ip_address_storage, user=user_name, password=password)
+        self.cmd_sender_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+        self.terminals = [self.proxy_terminal, self.storage_terminal, self.cmd_sender_terminal]
+
+    def runTest(self):
+        for terminal in self.terminals:
+            assert terminal.execute_as_root("whoami") == (f"root\n", 0)
+
+    def tearDown(self):
+        pass
+
+class TestMkdir(BaseTest):
+
+    def setUp(self):
+        self.proxy_terminal = ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password, )
+        self.storage_terminal = ExtendedTerminal(address=ip_address_storage, user=user_name, password=password)
+        self.cmd_sender_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+        self.terminals = [self.proxy_terminal, self.storage_terminal, self.cmd_sender_terminal]
+
+    def runTest(self):
+        path = "~/empty_test_folder"
+
+        for terminal in self.terminals:
+            terminal.mkdir(path)
+            out, _ = terminal.execute("ls ~/")
+            assert "empty_test_folder" in out
+            assert terminal.execute("rmdir ~/empty_test_folder")[1] == 0
+
+    def tearDown(self):
+        pass

--- a/build/storage/ptf_test/setup_tests/test_containers_deploy.py
+++ b/build/storage/ptf_test/setup_tests/test_containers_deploy.py
@@ -1,0 +1,24 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append('../')
+
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.containers_deploy import ContainersDeploy
+from ptf import testutils
+from ptf.base_tests import BaseTest
+from python_system_tools.data import cmd_docker_name
+
+
+class TestRunDockersContainers(BaseTest):
+
+    def setUp(self):
+        self.containers_deploy = ContainersDeploy()
+
+    def runTest(self):
+        assert self.containers_deploy.run_docker_containers() == [0, 0]
+        assert self.containers_deploy.run_docker_from_image(image=cmd_docker_name) == 0
+
+    def tearDown(self):
+        pass

--- a/build/storage/ptf_test/setup_tests/test_docker.py
+++ b/build/storage/ptf_test/setup_tests/test_docker.py
@@ -1,0 +1,72 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append('../')
+
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.docker import Docker
+from ptf import testutils
+from ptf.base_tests import BaseTest
+from python_system_tools.data import ip_address_proxy, ip_address_storage, ip_address_cmd_sender, user_name, password, \
+    storage_docker_image, proxy_docker_image, cmd_docker_name
+
+
+
+class TestImages(BaseTest):
+
+    def setUp(self):
+        self.proxy_terminal = ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password)
+
+    def runTest(self):
+        images = ("test-driver", "traffic-generator", "spdk-app")
+        out, _ = self.proxy_terminal.execute("docker images")
+        for image in images:
+            assert image in out
+
+    def tearDown(self):
+        pass
+
+
+class TestGetDockerID(BaseTest):
+
+    def setUp(self):
+        self.docker_proxy = Docker(address=ip_address_proxy, user=user_name, password=password)
+        self.docker_storage = Docker(address=ip_address_storage, user=user_name, password=password)
+
+    def runTest(self):
+        assert self.docker_storage.get_docker_id(storage_docker_image) is not None
+        assert self.docker_proxy.get_docker_id(proxy_docker_image) is not None
+
+    def tearDown(self):
+        pass
+
+
+class TestExecuteInDocker(BaseTest):
+
+    def setUp(self):
+        self.docker_proxy = Docker(address=ip_address_proxy, user=user_name, password=password)
+        self.docker_storage = Docker(address=ip_address_storage, user=user_name, password=password)
+
+    def runTest(self):
+        storage_container_id = self.docker_storage.get_docker_id(storage_docker_image)
+        proxy_container_id = self.docker_proxy.get_docker_id(proxy_docker_image)
+
+        cmd = "echo Hello, World!"
+
+        out, rc = self.docker_storage.execute_in_docker(cmd, storage_container_id, user_name)
+        assert out, rc == ("Hello, World!\n", 0)
+
+        out, rc = self.docker_proxy.execute_in_docker(cmd, proxy_container_id, user_name)
+        assert out, rc == ("Hello, World!\n", 0)
+
+    def tearDown(self):
+        self.docker_proxy.kill_container(
+            container_id=self.docker_proxy.get_docker_id(docker_image=proxy_docker_image))
+        self.docker_storage.kill_container(
+            container_id=self.docker_storage.get_docker_id(docker_image=storage_docker_image))
+        docker_cmd = Docker(address=ip_address_cmd_sender, user=user_name, password=password)
+        docker_cmd.kill_container(
+            container_id=docker_cmd.get_docker_id(docker_image=cmd_docker_name))
+
+

--- a/build/storage/ptf_test/setup_tests/test_setup.py
+++ b/build/storage/ptf_test/setup_tests/test_setup.py
@@ -1,0 +1,194 @@
+import json
+import logging
+import re
+import os
+import sys
+import time
+
+sys.path.append('../')
+
+from python_system_tools.consts import SCRIPTS_PATH, SHARE_DIR_PATH, WORKSPACE_PATH
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.docker import Docker
+from python_system_tools.setup import Setup
+from scripts.socket_functions import send_command_over_unix_socket
+from python_system_tools.data import ip_address_proxy, ip_address_storage, ip_address_cmd_sender, user_name, password, \
+    proxy_docker_image, storage_docker_image, cmd_docker_name
+from ptf import testutils
+from ptf.base_tests import BaseTest
+
+
+class TestOS(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+
+    def runTest(self):
+        print(self.setup_storage.os)
+        assert self.setup_storage.os in ("Fedora", "Ubuntu")
+        assert self.setup_proxy.os in ("Fedora", "Ubuntu")
+
+    def tearDown(self):
+        pass
+
+
+class TestPM(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        assert self.setup_storage.pm in ("dnf", "apt")
+        assert self.setup_proxy.pm in ("dnf", "apt")
+
+    def tearDown(self):
+        pass
+
+
+class TestCheckVirtualization(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        return_values = Setup.setup_on_both_machines(
+            self.setup_storage.check_virtualization,
+            self.setup_proxy.check_virtualization,
+            timeout=30,
+        )
+
+        assert return_values == (True, True)
+
+    def tearDown(self):
+        pass
+
+
+class TestCheckKVM(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        return_values = Setup.setup_on_both_machines(
+            self.setup_storage.check_kvm,
+            self.setup_proxy.check_kvm,
+            timeout=30
+        )
+
+        assert return_values == (True, True)
+
+    def tearDown(self):
+        pass
+
+
+class TestSetupDockerCompose(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        return_values = Setup.setup_on_both_machines(
+            self.setup_storage.setup_docker_compose,
+            self.setup_proxy.setup_docker_compose,
+            timeout=60,
+        )
+
+        assert return_values == (True, True)
+
+    def tearDown(self):
+        pass
+
+
+class TestSetupLibguestfsTools(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        return_values = Setup.setup_on_both_machines(
+            self.setup_storage.setup_libguestfs_tools,
+            self.setup_proxy.setup_libguestfs_tools,
+            timeout=30,
+        )
+
+        assert return_values == (True, True)
+
+    def tearDown(self):
+        pass
+
+
+class TestInstalled(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        return_values = Setup.setup_on_both_machines(
+            self.setup_storage.is_installed,
+            self.setup_proxy.is_installed,
+            timeout=60,
+        )
+
+        assert return_values == ([0, 0, 0], [0, 0, 0])
+
+    def tearDown(self):
+        pass
+
+
+class TestCheckSecurityPolicies(BaseTest):
+
+    def setUp(self):
+        self.setup_proxy = Setup(ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password))
+        self.setup_storage = Setup(ExtendedTerminal(address=ip_address_storage, user=user_name, password=password))
+
+    def runTest(self):
+        return_values = Setup.setup_on_both_machines(
+            self.setup_storage.check_security_policies,
+            self.setup_proxy.check_security_policies,
+            timeout=30,
+        )
+
+        assert return_values == (True, True)
+
+    def tearDown(self):
+        pass
+
+
+class TestRunVM(BaseTest):
+
+    def setUp(self):
+        self.cmd_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+
+    def runTest(self):
+        t = 60
+        pattern = 'vm.qcow2'
+        out, _ = self.cmd_terminal.execute(cmd=f"ls {SHARE_DIR_PATH}")
+        result = re.search(pattern=pattern, string=out)
+        if result is None:
+            logging.error(f"Cannot find {pattern} in {out}")
+            t = 420
+        cmd = f'SHARED_VOLUME={SHARE_DIR_PATH} UNIX_SERIAL=vm_socket scripts/vm/run_vm.sh &> /dev/null &'
+        self.cmd_terminal.execute_as_root(cmd=cmd, cwd=f'{os.path.join(WORKSPACE_PATH, "ipdk/build/storage")}')
+        time.sleep(t)
+        out, _ = self.cmd_terminal.execute(cmd=f"ls {SHARE_DIR_PATH}")
+        result = re.search(pattern=pattern, string=out)
+        assert result
+
+        user_out = send_command_over_unix_socket(f'{os.path.join(SHARE_DIR_PATH, "vm_socket")}', 'root', 2)
+        user_login_result = re.search(pattern='Password', string=user_out)
+        assert user_login_result
+
+        password_result = send_command_over_unix_socket(f'{os.path.join(SHARE_DIR_PATH, "vm_socket")}', 'root', 2)
+        user_password_result = re.search(pattern='root@', string=password_result)
+        assert user_password_result
+
+    def tearDown(self):
+        pass

--- a/build/storage/python_system_tools/consts.py
+++ b/build/storage/python_system_tools/consts.py
@@ -1,0 +1,10 @@
+import os.path
+import re
+from pathlib import Path
+
+# paths on master machine
+HOME_PATH = str(Path.cwd())
+HOME_PATH = re.search(pattern=r"\/\w*\/\w*\/", string=HOME_PATH).group(0)
+WORKSPACE_PATH = os.path.join(HOME_PATH, "IPDK_workspace")
+SHARE_DIR_PATH = os.path.join(WORKSPACE_PATH, "SHARE")
+SCRIPTS_PATH = os.path.join(WORKSPACE_PATH, "ipdk/build/storage/scripts")

--- a/build/storage/python_system_tools/containers_deploy.py
+++ b/build/storage/python_system_tools/containers_deploy.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import logging
+from typing import List
+
+
+sys.path.append('../')
+
+from python_system_tools.consts import WORKSPACE_PATH
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.setup import Setup
+from python_system_tools.data import ip_address_proxy, ip_address_storage, ip_address_cmd_sender, user_name, password
+
+
+class ContainersDeploy:
+    """
+    A class used to represent a deployment of the storage and proxy containers
+
+    ...
+
+    Attributes
+    ----------
+    proxy_terminal: ExtendedTerminal
+        A session with an SSH server on a proxy target
+    storage_terminal: ExtendedTerminal
+        A session with an SSH server on a storage target
+    workspace_path: str
+        A path of the workspace
+    repo_path: str
+        A path of the repository
+    storage_path: str
+        A path of the storage
+    shared_volume_path: str
+        A path of the shared volume
+
+    Methods
+    -------
+    run_docker_containers()
+        Run storage target container and proxy container
+    run_vm_instance_on_proxy_container_platform()
+        Run VM on a proxy container
+    """
+
+    def __init__(self):
+
+        self.proxy_terminal = ExtendedTerminal(address=ip_address_proxy, user=user_name, password=password)
+        self.storage_terminal = ExtendedTerminal(address=ip_address_storage, user=user_name, password=password)
+        self.cmd_sender_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+
+        self.workspace_path = WORKSPACE_PATH
+        self.repo_path = os.path.join(self.workspace_path, "ipdk")
+        self.storage_path = os.path.join(
+            self.workspace_path,
+            "ipdk/build/storage",
+        )
+        self.shared_volume_path = os.path.join(self.workspace_path, "SHARE")
+
+    def run_docker_containers(self) -> List[int]:
+        """
+        Run storage target container and proxy container
+
+        Returns
+        -------
+        tuple(int, int)
+            A tuple of return codes from running containers
+        """
+
+        self.proxy_terminal.mkdir(path=self.shared_volume_path)
+        return_codes = []
+        _, rc = self.storage_terminal.execute_as_root(cwd=self.storage_path,
+                                                      cmd="AS_DAEMON=true scripts/run_storage_target_container.sh")
+        return_codes.append(rc)
+        _, rc = self.proxy_terminal.execute_as_root(cwd=self.storage_path,
+                                                    cmd=f"AS_DAEMON=true SHARED_VOLUME={self.shared_volume_path} "
+                                                        f"scripts/run_ipu_storage_container.sh",)
+        return_codes.append(rc)
+        return return_codes
+
+    def run_docker_from_image(self, image):
+        out, rc = self.cmd_sender_terminal.execute_as_root(f'docker run --mount type=bind,source="{WORKSPACE_PATH}",'
+                                                           f'target=/workspace -d -it --privileged --network host '
+                                                           f'--entrypoint /bin/bash {image}')
+        out = out.strip()
+        logging.info(f"Docker started with id: {out}")
+        return rc
+
+    def run_vm_instance_on_proxy_container_platform(self):
+        """Run VM on a proxy container"""
+
+        self.proxy_terminal.execute_as_root(
+            cmd=f"cd {self.storage_path} && SHARED_VOLUME={self.shared_volume_path} "
+            f"./scripts/vm/run_vm.sh"
+        )
+
+    def run_tests(self) -> bool:
+        """Run tests on a proxy container and build docker images"""
+
+        _, rc = self.proxy_terminal.execute_as_root(
+            cmd="tests/it/run.sh", cwd=self.storage_path
+        )
+        return not rc

--- a/build/storage/python_system_tools/data.json
+++ b/build/storage/python_system_tools/data.json
@@ -1,0 +1,10 @@
+{
+    "user": "",
+    "password": "",
+    "cmd_address": "",
+    "cmd_docker_name": "test-driver",
+    "storage_address": "",
+    "storage_docker_image": "storage-target",
+    "proxy_address": "",
+    "proxy_docker_image": "ipu-storage-container"
+}

--- a/build/storage/python_system_tools/data.py
+++ b/build/storage/python_system_tools/data.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+path = Path.cwd()
+data_path = path.parent / "python_system_tools/data.json"
+with open(file=data_path) as f:
+    data = json.load(f)
+
+ip_address_proxy = data["proxy_address"]
+proxy_docker_image = data["proxy_docker_image"]
+
+ip_address_storage = data["storage_address"]
+storage_docker_image = data["storage_docker_image"]
+
+ip_address_cmd_sender = data["cmd_address"]
+cmd_docker_name = data["cmd_docker_name"]
+
+user_name = data["user"]
+password = data['password']
+nqn = 'nqn.2016-06.io.spdk:cnode0'
+spdk_port = 5260
+nvme_port = '4420'
+sma_port = 8080

--- a/build/storage/python_system_tools/docker.py
+++ b/build/storage/python_system_tools/docker.py
@@ -1,0 +1,135 @@
+import logging
+import re
+import sys
+from typing import Optional, Tuple
+
+sys.path.append('../')
+
+
+from python_system_tools.extendedterminal import ExtendedTerminal
+
+
+class DockerException(Exception):
+    """A custom Exception of a Docker class"""
+
+
+class Docker(ExtendedTerminal):
+    """
+    A subclass of ExtendedTerminal used to represent Docker specific operations
+
+    ...
+
+    Attributes
+    ----------
+    container_ids: set
+        A set of container ids
+
+    Methods
+    -------
+    execute_in_docker(cmd, container_id, raise_on_error=True)
+        Executes a command in docker container with a given id,
+        raises error when command execution fails and raise_on_error is set to True (default True)
+    get_docker_id(docker_image)
+        Checks a container id based on the docker image
+    kill_container(container_id)
+        Kills a container with a given id
+    kill_all_containers()
+        Kills all containers
+    """
+
+    def __init__(self, address: str, user: str, password: str):
+        """
+        Parameters
+        ----------
+        address: str
+            An IP address of an SSH server
+        user: str
+            A user's name
+        password: str
+            A user's password
+        """
+
+        super().__init__(address, user, password)
+        self.container_ids = set()
+
+    def execute_in_docker(
+        self, cmd: str, container_id: str, raise_on_error=True
+    ) -> Tuple[str, int]:
+        """
+        Executes a command in docker container with a given id
+
+        Parameters
+        ----------
+        cmd: str
+            The command to execute
+        container_id: str
+            A container id
+        raise_on_error: bool
+            Specify if error is raised when the command execution fails (default True)
+
+        Returns
+        -------
+        tuple(str, int)
+            The tuple of the output and return code of the executed command
+
+        Raises
+        ------
+        ExtendedTerminalException
+            When command execution fails and raise_on_error is set to True (default True)
+        """
+
+        logging.info(f"Execute command {cmd}\non docker {container_id}")
+        return self.execute(
+            f'docker exec {container_id} sh -c "{cmd}"', raise_on_error=raise_on_error
+        )
+
+    def get_docker_id(self, docker_image: str) -> Optional[str]:
+        """
+        Checks a container id based on the docker image
+
+        Parameters
+        ----------
+        docker_image: str
+            A docker image
+
+        Returns
+        -------
+        str | None
+            A container id or None if there is no match
+        """
+
+        out, _ = self.execute("docker ps")
+        regex = re.compile(rf"(?<=\n)\w{{12}}(?=\s+{docker_image})")
+        return regex.search(out).group()
+
+    def kill_container(self, container_id: str) -> Tuple[str, int]:
+        """
+        Kills a container with a given id
+
+        Parameters
+        ----------
+        container_id: str
+            A container id
+
+        Returns
+        -------
+        tuple(str, int)
+            The tuple of the output and return code of the executed command
+        """
+
+        logging.info(f"Kill docker container {container_id}")
+        return self.execute(f"docker kill {container_id}")
+
+    def kill_all_containers(self) -> None:
+        """Kills all containers"""
+
+        left_alive_containers = set()
+        for container_id in self.container_ids:
+            out, rc = self.kill_container(container_id)
+            if rc:
+                logging.warning(
+                    f"Cannot kill docker container: {container_id}. An attempt to kill it resulted in rc: "
+                    f"{rc}\n output: {out}"
+                )
+                left_alive_containers.add(container_id)
+        self.container_ids = left_alive_containers

--- a/build/storage/python_system_tools/extendedterminal.py
+++ b/build/storage/python_system_tools/extendedterminal.py
@@ -1,0 +1,186 @@
+import logging
+import time
+from typing import Tuple, Optional
+
+from paramiko.client import SSHClient, AutoAddPolicy
+from paramiko.ssh_exception import SSHException
+
+
+class ExtendedTerminalException(Exception):
+    """A custom Exception of an ExtendedTerminal class"""
+
+
+class ExtendedTerminal:
+    """
+    A class used to represent a session with an SSH server
+
+    ...
+
+    Attributes
+    ----------
+    address: str
+        An IP address of an SSH server
+    user: str
+        A user's name
+    password: str
+        A user's password
+    terminal: SSHClient
+        A high-level representation of a session with an SSH server
+
+    Methods
+    -------
+    initialize_terminal(address, user, password)
+        Initializes an SSH connection to an SSH server with given address, using given credentials
+    disconnect()
+        Closes an SSH session
+    execute(cmd, timeout=None, raise_on_error=True)
+        Executes a command on an SSH server with given timeout (default None) and
+        raises an error if a command execution fails and raise_on_error is equal to True (default True)
+    execute_as_root(cmd, cwd=None, raise_on_error=None)
+        Executes a command on an SSH server as a root within given directory (default None) and
+        raises an error if a command execution fails and raise_on_error is equal to True (default True)
+    mkdir(path, parents=True)
+        Makes an empty directory
+    """
+
+    def __init__(self, address: str, user: str, password: str):
+        """
+        Parameters
+        ----------
+        address: str
+            An IP address of an SSH server
+        user: str
+            A user's name
+        password: str
+            A user's password
+        """
+
+        self.address = address
+        self.user = user
+        self.password = password
+        self.terminal: SSHClient = self.initialize_terminal(
+            address=self.address, password=self.password, user=self.user
+        )
+
+    @staticmethod
+    def initialize_terminal(address: str, user: str, password: str) -> SSHClient:
+        """
+        Initializes an SSH connection to an SSH server with given address, using given credentials
+
+        Parameters
+        ----------
+        address: str
+            An IP address of an SSH server
+        user: str
+            A user's name
+        password: str
+            A user's password
+
+        Returns
+        -------
+        SSHClient
+            A high-level representation of a session with an SSH server
+        """
+
+        terminal = SSHClient()
+        terminal.load_system_host_keys()
+        terminal.set_missing_host_key_policy(AutoAddPolicy)
+
+        max_attempt = 3
+        delay = 5
+        for attempt in range(max_attempt):
+            try:
+                terminal.connect(hostname=address, username=user, password=password)
+                break
+            except SSHException:
+                logging.warning(
+                    f"Could not connect to pppd through tunnel. Attempts left: {max_attempt - attempt}"
+                )
+                attempt_delay = delay * attempt
+                logging.info(f"Delaying next attempt for {attempt_delay} seconds")
+                time.sleep(attempt_delay)
+        return terminal
+
+    def disconnect(self) -> None:
+        """Closes an SSH session"""
+
+        self.terminal.close()
+
+    def execute(
+            self, cmd: str, timeout: Optional[float] = None, raise_on_error: bool = True
+    ) -> Tuple[str, int]:
+        """
+        Executes a command on the SSH server
+
+        Parameters
+        ----------
+        cmd: str
+            The command to execute
+        timeout: float | None
+            Set command's channel timeout (default None)
+        raise_on_error: bool
+            Specify if error is raised when the command execution fails (default True)
+
+        Returns
+        -------
+        tuple(str, int)
+            The tuple of the output and return code of the executed command
+
+        Raises
+        ------
+        ExtendedTerminalException
+            When the execution of the command fails and raise_on_error parameter is equal to True
+        """
+
+        logging.info(f'Execute command: "{cmd}" with timeout={timeout}')
+        _, stdout, stderr = self.terminal.exec_command(cmd, timeout=timeout)
+        rc = stdout.channel.recv_exit_status()
+
+        #  if command is executed in the background don't wait for the output
+        out = "" if cmd.rstrip().endswith("&") else (stdout.read() or stderr.read()).decode()
+
+        if raise_on_error and rc:
+            raise ExtendedTerminalException(f"Command execution failed")
+        elif not raise_on_error and rc:
+            logging.error(f"Command failed with\nrc={rc}\nout={out}")
+        else:
+            logging.info(f"Command executed with\nrc={rc}\nout={out}")
+
+        return out, rc
+
+    def execute_as_root(
+            self, cmd: str, cwd: Optional[str] = None, raise_on_error: bool = True
+    ) -> Tuple[str, int]:
+        """
+        Executes a command on the SSH server as root
+
+        Parameters
+        ----------
+        cmd: str
+            The command to execute
+        cwd: str | None
+            Set the directory in which the command should be executed (default None)
+        raise_on_error: bool
+            Specify if error is raised when the command execution fails (default True)
+
+        Returns
+        -------
+        tuple(str, int)
+            The tuple of the output and return code of the executed command
+
+        Raises
+        ------
+        ExtendedTerminalException
+            When the execution of the command fails and raise_on_error parameter is equal to True
+        """
+
+        if cwd:
+            return self.execute(f"cd {cwd} && sudo {cmd}", raise_on_error=raise_on_error)
+        return self.execute(f"sudo {cmd}", raise_on_error=raise_on_error)
+
+    def mkdir(self, path: str, parents: bool = True) -> None:
+        """Creates an empty directory with given path or nested directories if parents is set to True"""
+
+        infix = "-p" if parents else ""
+        cmd = f"mkdir {infix} {path}"
+        self.execute(cmd)

--- a/build/storage/python_system_tools/setup.py
+++ b/build/storage/python_system_tools/setup.py
@@ -1,0 +1,269 @@
+import logging
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+sys.path.append('../')
+
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.consts import WORKSPACE_PATH
+
+
+class UnknownOSError(Exception):
+    """A custom Exception of a Setup class"""
+
+
+class Setup:
+    """
+    A class used to represent a setup of a machine
+
+    ...
+
+    Attributes
+    ----------
+    pms: dict
+        A dictionary that maps package manager to an operating system
+    terminal: ExtendedTerminal
+        Represents a session with an SSH server
+    os: str
+        The name of an operating system
+    pm: str
+        The name of a package manager
+
+    Methods
+    -------
+    check_virtualization()
+        Checks if VT-x/AMD-v support is enabled in BIOS
+    check_kvm()
+        Checks if kvm modules are loaded
+    check_system()
+        Checks the type of OS and returns it, raises UnknownOSError if it's unrecognized
+    install(program)
+        Installs a program on a machine
+    setup_docker_compose()
+        Checks if docker-compose is installed and installs it if it's not
+    setup_libguestfs_tools()
+        Installs libguestfs-tools for a specific OS
+    change_vmlinuz()
+        Changes the mode of /boot/vmlinuz-*
+    check_security_policies()
+        Checks if security policies are disabled
+    """
+
+    pms = {"Fedora": "dnf", "Ubuntu": "apt"}
+
+    def __init__(self, terminal: ExtendedTerminal):
+        """
+        Parameters
+        ----------
+        terminal: ExtendedTerminal
+            A session with an SSH server
+        """
+
+        self.terminal = terminal
+        self.os = self.check_system()
+        self.pm = self.pms[self.os]
+
+    def check_virtualization(self) -> bool:
+        """
+        Checks if VT-x/AMD-v support is enabled in BIOS
+
+        Returns
+        -------
+        bool
+            True if virtualization support is enabled in BIOS else False
+        """
+
+        logging.info("Checking if VT-x/AMD-v support is enabled in BIOS")
+        regex = re.compile(r"vt-x|amd-v|full", re.IGNORECASE)
+        out, _ = self.terminal.execute("lscpu | grep -i virtualization")
+        if regex.search(out):
+            logging.info("Virtualization support is enabled in BIOS")
+            return True
+        logging.error("Virtualization support is not enabled in BIOS")
+        return False
+
+    def check_kvm(self) -> bool:
+        """
+        Checks if kvm modules are loaded
+
+        Returns
+        -------
+        bool
+            True if kvm modules are loaded else False
+        """
+
+        logging.info("Checking if kvm modules are loaded")
+        out, _ = self.terminal.execute("lsmod | grep -i kvm")
+        if re.search(r"kvm_intel|kvm_amd", out):
+            logging.info("kvm modules are loaded")
+            return True
+        logging.error("kvm modules are not loaded")
+        return False
+
+    def check_system(self) -> Optional[str]:
+        """
+        Checks if kvm modules are loaded
+
+        Returns
+        -------
+        str | None
+            The name of operating system or None if it's unrecognized
+
+        Raises
+        ------
+        UnknownOSError
+            The error raised when the operating system is unrecognized (different than Fedora or Ubuntu)
+        """
+
+        logging.info("Checking operating system")
+        out, _ = self.terminal.execute("cat /etc/os-release")
+        if match := re.search(r"Fedora|Ubuntu", out):
+            logging.info(f"Operating system is {match.group()}")
+            return match.group()
+        logging.error("Unrecognized operating system")
+        raise UnknownOSError("Unsupported OS")
+
+    def install(self, program: str) -> bool:
+        """
+        Installs a program on a machine
+
+        Parameters
+        ----------
+        program: str
+            The name of a program to install
+
+        Returns
+        -------
+        bool
+            True if program is installed successfully or present on a machine else False
+        """
+
+        logging.info(f"Installing {program}")
+        out, rc = self.terminal.execute_as_root(f"{self.pm} -y install {program}")
+        if rc:
+            logging.error(
+                f"Installing {program} failed with code {rc} and output {out}"
+            )
+            return False
+        logging.info(f"{program} installed successfully or present on a machine")
+        return True
+
+    def setup_docker_compose(self) -> bool:
+        """
+        Checks if docker-compose is installed and installs it if it's not
+
+        Returns
+        -------
+        bool
+            True if setup is successful or docker-compose is already installed else False
+        """
+
+        cmds = (
+            'curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose',
+            "chmod +x /usr/local/bin/docker-compose",
+            "ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose",
+        )
+        _, rc = self.terminal.execute("docker-compose --version", raise_on_error=False)
+        if rc:
+            logging.info("Setting up docker-compose")
+            for cmd in cmds:
+                out, rc = self.terminal.execute_as_root(cmd)
+                if rc:
+                    logging.error(
+                        f"Setting up docker failed with code {rc} and output {out}"
+                    )
+                    return False
+            logging.info(f"Setup of docker-compose was successful")
+            return True
+        logging.info(f"docker-compose is already installed")
+        return True
+
+    def setup_libguestfs_tools(self) -> bool:
+        """
+        Installs libguestfs-tools for a specific OS
+
+        Returns
+        -------
+        bool
+            True if installation is successful else False
+        """
+
+        program = "libguestfs-tools"
+        if self.os == "Fedora":
+            program += "-c"
+        return self.install(program)
+
+    def change_vmlinuz(self) -> bool:
+        """
+        Changes the mode of /boot/vmlinuz-*
+
+        Returns
+        -------
+        bool
+            True if change is successful else False
+        """
+
+        out, rc = self.terminal.execute_as_root("chmod +r /boot/vmlinuz-*")
+        if rc:
+            logging.error(
+                f"Changing the mode of /boot/vmlinuz-* failed with code {rc} and output {out}"
+            )
+            return False
+        logging.info("Mode of /boot/vmlinuz-* was changed")
+        return True
+
+    def check_security_policies(self) -> bool:
+        """
+        Checks if security policies are disabled
+
+        Returns
+        -------
+        bool
+            True if security policies are disabled else False
+        """
+
+        if self.os == "Fedora":
+            cmd = "setenforce 0"
+        else:
+            cmd = "systemctl stop apparmor"
+        out, rc = self.terminal.execute_as_root(cmd, raise_on_error=False)
+        if "disabled" in out:
+            logging.info("Security policies are disabled")
+            return True
+        logging.error(
+            f"Disabling security policies failed with code {rc} and output {out}"
+        )
+        return False
+
+    def clone_repo(self, branch=None):
+        self.terminal.mkdir(WORKSPACE_PATH)
+        if branch:
+            return self.terminal.execute_as_root(
+                f"git clone -b {branch} https://github.com/ipdk-io/ipdk.git",
+                cwd=WORKSPACE_PATH,
+            )
+        else:
+            return self.terminal.execute_as_root(
+                "git clone https://github.com/ipdk-io/ipdk.git",
+                cwd=WORKSPACE_PATH,
+            )
+
+    def is_installed(self):
+        cmds = ("docker --version", "wget --version", "docker-compose --version")
+        rcs = [self.terminal.execute(cmd)[1] for cmd in cmds]
+        return rcs
+
+    @staticmethod
+    def setup_on_both_machines(
+        function1, function2, args1=[], args2=[], kwargs1={}, kwargs2={}, timeout=None
+    ):
+        with ThreadPoolExecutor() as executor:
+            future_storage = executor.submit(function1, *args1, **kwargs1)
+            future_proxy = executor.submit(function2, *args2, **kwargs2)
+            return_values = (
+                future_storage.result(timeout=timeout),
+                future_proxy.result(timeout=timeout),
+            )
+        return return_values

--- a/build/storage/python_system_tools/setup_teardown.py
+++ b/build/storage/python_system_tools/setup_teardown.py
@@ -1,0 +1,47 @@
+import re
+import sys
+import os
+import time
+
+sys.path.append('../')
+
+from python_system_tools.consts import SHARE_DIR_PATH, WORKSPACE_PATH
+from python_system_tools.containers_deploy import ContainersDeploy
+from python_system_tools.docker import Docker
+from python_system_tools.extendedterminal import ExtendedTerminal
+from python_system_tools.data import ip_address_proxy, ip_address_storage, ip_address_cmd_sender, user_name, password, \
+    storage_docker_image, proxy_docker_image, cmd_docker_name
+
+
+def set_for_test():
+    containers_deploy = ContainersDeploy()
+    containers_deploy.run_docker_containers()
+    containers_deploy.run_docker_from_image(image=cmd_docker_name)
+
+    cmd_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+    cmd = f'SHARED_VOLUME={SHARE_DIR_PATH} UNIX_SERIAL=vm_socket scripts/vm/run_vm.sh &> /dev/null &'
+    cmd_terminal.execute_as_root(cmd=cmd, cwd=f'{os.path.join(WORKSPACE_PATH, "ipdk/build/storage")}')
+    time.sleep(60)
+
+
+def tear_down_for_test():
+    docker_proxy = Docker(address=ip_address_proxy, user=user_name, password=password)
+    docker_storage = Docker(address=ip_address_storage, user=user_name, password=password)
+    docker_cmd = Docker(address=ip_address_cmd_sender, user=user_name, password=password)
+
+    docker_proxy.kill_container(
+        container_id=docker_proxy.get_docker_id(docker_image=proxy_docker_image))
+    docker_storage.kill_container(
+        container_id=docker_storage.get_docker_id(docker_image=storage_docker_image))
+    docker_cmd.kill_container(
+        container_id=docker_cmd.get_docker_id(docker_image=cmd_docker_name))
+
+    cmd_terminal = ExtendedTerminal(address=ip_address_cmd_sender, user=user_name, password=password)
+    cmd_terminal.execute_as_root(cmd=f"rm -f vm_socket", cwd=SHARE_DIR_PATH)
+    out, _ = cmd_terminal.execute(cmd="sudo netstat -plten | grep 5555")
+    process_pid = re.search(pattern="(\d*)\/qemu-system", string=out).group(1)
+    cmd_terminal.execute_as_root(cmd=f"kill -9 {process_pid}")
+
+
+
+


### PR DESCRIPTION
Add ptf tests which setup the environment for further testing.

Tests that setup the environment were added within a new `ptf_test` directory. After running those, the environment is ready for further integration testing. Within `ptf_test` directory a README file was added which contains instructions to follow. Moreover another new directory was created `python_system_tools` which contains tools used by the tests eg. ExtendedTerminal which is a high level abstraction of an SSH Client.
Implemented functionality:
-checking virtualization support
-checking and installing required tools
-setting up security policies
-deploying containers on the machines
-running and logging to a Virtual Machine

Signed-off-by: rilnickx <rafalx.ilnicki@intel.com>