### PR TITLE
Run storage cmd-sender as separate container.

### DIFF
--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -178,11 +178,11 @@ ENTRYPOINT ["/init"]
 
 
 ################################################################################
-# test-driver
+# cmd-sender
 #
-# Used as a control point to issue commands to other containers
+# Contains all required tools to send control commands to other containers.
 ################################################################################
-FROM spdk-app AS test-driver
+FROM spdk-app AS cmd-sender-base
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -191,6 +191,18 @@ RUN dnf install -y socat grpc-cli jq && dnf clean all
 
 COPY tests/it/test-drivers/test-helpers /test-helpers
 COPY scripts/ /scripts
+
+FROM cmd-sender-base AS cmd-sender
+RUN echo "source /scripts/disk_infrastructure.sh" >> ~/.bashrc
+ENTRYPOINT ["/bin/bash"]
+
+
+################################################################################
+# test-driver
+#
+# Issues all control commands for other containers in tests.
+################################################################################
+FROM cmd-sender-base AS test-driver
 
 ENTRYPOINT ["/init"]
 

--- a/build/storage/recipes/environment_setup.md
+++ b/build/storage/recipes/environment_setup.md
@@ -129,27 +129,8 @@ Finally vm console will be opened.
 
 login:password pair for the vm is `root:root`.
 
-4. Prepare environment to send commands to the storage containers.
-For that purpose we need to have spdk rpc.py and grpc-cli tools available.
-`test-driver` image
-fits for this purpose well since it contains all required tools.
-Let's use `test-driver` image instance to send all required commands.
-In the recipes this `test-driver` will be referred as `cmd-sender` to
-increase comprehension of the text. However, we should keep in mind that
-`cmd-sender` is a running instance of `test-driver` image.
-
-To use `test-driver` run the following command on `ipu-storage-container-platform`
-machine.
+4. Prepare environment to send commands to the containers.
+Use `cmd-sender` on `ipu-storage-container-platform` machine.
 ```
-$ scripts/build_container.sh test-driver
-```
-
-Run `test-driver` on `ipu-storage-container-platform` machine
-```
-$ docker run -it --privileged --network host --entrypoint /bin/bash test-driver
-```
-
-Source supplementary scripts in running `test-driver` container
-```
-$ source /scripts/disk_infrastructure.sh
+$ scripts/run_cmd_sender.sh
 ```

--- a/build/storage/scripts/build_container.sh
+++ b/build/storage/scripts/build_container.sh
@@ -42,7 +42,8 @@ function traffic_generator_build_cleanup() {
 container_to_build="${1}"
 
 possible_containers=("storage-target" "ipu-storage-container" \
-  "host-target" "traffic-generator" "test-driver" "ipdk-unit-tests")
+  "host-target" "traffic-generator" "test-driver" "ipdk-unit-tests" \
+  "cmd-sender")
 if [[ " ${possible_containers[*]} " =~ ${container_to_build} ]]; then
     export DOCKER_BUILDKIT="${DOCKER_BUILDKIT}"
     if [ "$container_to_build" == "traffic-generator" ]; then

--- a/build/storage/scripts/run_cmd_sender.sh
+++ b/build/storage/scripts/run_cmd_sender.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[ "$DEBUG" == 'true' ] && set -x
+
+export IMAGE_NAME="cmd-sender"
+export BUILD_IMAGE="true"
+scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+# shellcheck source=./scripts/run_container.sh
+# shellcheck disable=SC1091,SC1090
+source "${scripts_dir}/run_container.sh"


### PR DESCRIPTION
Sending cmds from test-driver confuses users.
To avoid this commands to storage containers will be sent from dedicated container.
