### PR TITLE
Improve host-target validity check.

### DIFF
--- a/build/storage/scripts/vm/prepare_vm.sh
+++ b/build/storage/scripts/vm/prepare_vm.sh
@@ -30,6 +30,8 @@ releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
     host_target_tar_file_name=$(basename "${HOST_TARGET_TAR}")
     vm_host_target_tar_dir="/"
     vm_host_target_tar_path="${vm_host_target_tar_dir}${host_target_tar_file_name}"
+    run_host_target_container_script="run_host_target_container.sh"
+    run_container_script="run_container.sh"
     if [ ! -f "${HOST_TARGET_TAR}" ]; then
         host_target_container_name="host-target"
         "${scripts_dir}"/build_container.sh "$host_target_container_name"
@@ -45,8 +47,8 @@ releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
     run_customize+=(--run-command 'grubby --update-kernel ALL --args selinux=0')
     run_customize+=(--install "dnf-plugins-core,docker-ce,docker-ce-cli,containerd.io")
     run_customize+=(--copy-in "${HOST_TARGET_TAR}:${vm_host_target_tar_dir}")
-    run_customize+=(--copy-in "${scripts_dir}/run_host_target_container.sh:/usr/local/bin")
-    run_customize+=(--copy-in "${scripts_dir}/run_container.sh:/usr/local/bin")
+    run_customize+=(--copy-in "${scripts_dir}/$run_host_target_container_script:/usr/local/bin")
+    run_customize+=(--copy-in "${scripts_dir}/$run_container_script:/usr/local/bin")
     run_customize+=(--run-command 'systemctl enable docker.service')
     run_customize+=(--run-command 'service docker start')
     run_customize+=(--append-line "${systemd_host_target_service}:[Unit]")
@@ -64,6 +66,9 @@ releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
     run_customize+=(--firstboot-command "rm -f ${vm_host_target_tar_path}")
     run_customize+=(--firstboot-command 'systemctl start host-target')
     run_customize+=(--firstboot-command 'systemctl enable host-target')
+    run_customize+=(--run-command "test -s $vm_host_target_tar_path")
+    run_customize+=(--run-command "test -f /usr/local/bin/$run_host_target_container_script")
+    run_customize+=(--run-command "test -f /usr/local/bin/$run_container_script")
 
     "${run_customize[@]}"
     mv "${vm_tmp_file}" "${DRIVE_TO_BOOT}"

--- a/build/storage/scripts/vm/run_vm.sh
+++ b/build/storage/scripts/vm/run_vm.sh
@@ -6,6 +6,8 @@
 
 [ "$DEBUG" == 'true' ] && set -x
 
+set -e
+
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/..
 # shellcheck disable=SC1091,SC1090
 source "$scripts_dir"/vm/vm_default_variables.sh

--- a/build/storage/tests/it/test-drivers/test-helpers
+++ b/build/storage/tests/it/test-drivers/test-helpers
@@ -65,6 +65,17 @@ function wait_until_host_target_is_up() {
 		sleep "${wait_period_sec}"
 		wait_counter=$(( wait_counter + 1 ))
 	done
+	cmd="docker image ls"
+	out=$(send_command_over_unix_socket "${console}" "$cmd" 1)
+	echo "$out"
+
+	cmd="service docker status | cat"
+	out=$(send_command_over_unix_socket "${console}" "$cmd" 1)
+	echo "$out"
+
+	cmd="systemctl status host-target | cat"
+	out=$(send_command_over_unix_socket "${console}" "$cmd" 1)
+	echo "$out"
 	return 1
 }
 


### PR DESCRIPTION
In this patch, it is checked if all required tools to run host-target are copied into vm.
In case, host-target didn't start, additional information will be printed in tests.
