### PR TITLE
Fix PATH variable configurations in start.sh utility script

### DIFF
--- a/build/networking/scripts/start.sh
+++ b/build/networking/scripts/start.sh
@@ -6,7 +6,7 @@
 initialize_env() {
 	pushd /root/scripts > /dev/null  || exit
 		# shellcheck source=/dev/null
-		. p4ovs_env_setup.sh /root/p4-sde/install > /dev/null
+		. p4ovs_env_setup.sh /root/p4-sde/install /root/p4ovs/P4OVS_DEPS_INSTALL > /dev/null
 	popd > /dev/null || exit
 }
 


### PR DESCRIPTION
Modified utility script.sh to use the custom P4 OvS path for setting PATH and LD_LIBRARY_PATH environment variables

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>