### PR TITLE
Run fio against multiple volumes with dedicated jobs.

### DIFF
--- a/build/storage/core/host-target/helpers/fio_args.py
+++ b/build/storage/core/host-target/helpers/fio_args.py
@@ -32,19 +32,22 @@ class FioArgs:
             self._file.__exit__(exc_type, exc_val, exc_tb)
 
         def _dump_owner_to_file(self, file: typing.TextIO) -> None:
-            file.write("[job0]\n")
+            file.write("[global]\n")
             for arg_key in self._owner._fio_args:
-                if arg_key == self._owner._volume_to_exercise_option:
-                    file.write(
-                        arg_key
-                        + "="
-                        + ":".join(map(str, self._owner._fio_args[arg_key]))
-                        + "\n"
-                    )
-                else:
+                if arg_key != self._owner._volume_to_exercise_option:
                     file.write(
                         arg_key + "=" + str(self._owner._fio_args[arg_key]) + "\n"
                     )
+
+            if self._owner._volume_to_exercise_option in self._owner._fio_args:
+                for volume in self._owner._fio_args[
+                    self._owner._volume_to_exercise_option
+                ]:
+                    file.write(f"[job ({volume})]\n")
+                    file.write(
+                        self._owner._volume_to_exercise_option + "=" + volume + "\n"
+                    )
+
             file.flush()
 
     def __init__(self, fio_args_str: str) -> None:

--- a/build/storage/recipes/nvme/fio.md
+++ b/build/storage/recipes/nvme/fio.md
@@ -75,3 +75,70 @@ Disk stats (read/write):
  nvme0n1: ios=19160/19467, merge=0/0, ticks=199017/202255, in_queue=401271, util=95.89%
 
 ```
+
+To exercise all volumes attached to a device, just leave `volumeId` argument in a command.
+```
+$ echo -e $(no_grpc_proxy="" grpc_cli call <host_ip_where_vm_is_run>:50051 \
+        RunFio "diskToExercise: { deviceHandle: '$nvme0' } \
+        fioArgs: '{\"rw\":\"randrw\",\"runtime\":10, \
+            \"time_based\": 1, \"iodepth\": 32, \
+            \"direct\": 1, \"ioengine\": \"libaio\" }'")
+```
+Expected output with 2 attached volumes
+```
+fioOutput: "job (/dev/nvme0n1): (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=32
+job (/dev/nvme0n2): (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=32
+fio-3.29
+Starting 2 processes
+
+job (/dev/nvme0n1): (groupid=0, jobs=1): err= 0: pid=39: Mon Nov 7 15:57:14 2022
+ read: IOPS=6724, BW=26.3MiB/s (27.5MB/s)(263MiB/10013msec)
+ slat (nsec): min=872, max=97402, avg=3454.77, stdev=2310.89
+ clat (usec): min=521, max=21986, avg=4753.67, stdev=3945.17
+ lat (usec): min=534, max=21992, avg=4757.32, stdev=3945.05
+ clat percentiles (usec):
+ | 1.00th=[ 2409], 5.00th=[ 2606], 10.00th=[ 2671], 20.00th=[ 2737],
+ | 30.00th=[ 2769], 40.00th=[ 2802], 50.00th=[ 2802], 60.00th=[ 2868],
+ | 70.00th=[ 2900], 80.00th=[ 3752], 90.00th=[12649], 95.00th=[12780],
+ | 99.00th=[13435], 99.50th=[13829], 99.90th=[15795], 99.95th=[16909],
+ | 99.99th=[21890]
+ bw ( KiB/s): min=26384, max=27464, per=50.04%, avg=26918.80, stdev=269.95, samples=20
+ iops : min= 6596, max= 6866, avg=6729.70, stdev=67.49, samples=20
+ lat (usec) : 750=0.01%
+ lat (msec) : 2=0.05%, 4=79.98%, 10=0.49%, 20=19.43%, 50=0.05%
+ cpu : usr=1.85%, sys=3.61%, ctx=57010, majf=0, minf=43
+ IO depths : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
+ submit : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
+ complete : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
+ issued rwts: total=67329,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+ latency : target=0, window=0, percentile=100.00%, depth=32
+job (/dev/nvme0n2): (groupid=0, jobs=1): err= 0: pid=40: Mon Nov 7 15:57:14 2022
+ read: IOPS=6724, BW=26.3MiB/s (27.5MB/s)(263MiB/10013msec)
+ slat (nsec): min=865, max=60886, avg=3487.73, stdev=2166.24
+ clat (usec): min=938, max=22036, avg=4753.05, stdev=3944.38
+ lat (usec): min=954, max=22041, avg=4756.72, stdev=3944.26
+ clat percentiles (usec):
+ | 1.00th=[ 2409], 5.00th=[ 2606], 10.00th=[ 2704], 20.00th=[ 2737],
+ | 30.00th=[ 2769], 40.00th=[ 2802], 50.00th=[ 2802], 60.00th=[ 2868],
+ | 70.00th=[ 2900], 80.00th=[ 3916], 90.00th=[12649], 95.00th=[12780],
+ | 99.00th=[13435], 99.50th=[13698], 99.90th=[15795], 99.95th=[16909],
+ | 99.99th=[21890]
+ bw ( KiB/s): min=26248, max=27328, per=50.05%, avg=26924.25, stdev=306.98, samples=20
+ iops : min= 6562, max= 6832, avg=6731.05, stdev=76.76, samples=20
+ lat (usec) : 1000=0.01%
+ lat (msec) : 2=0.12%, 4=79.88%, 10=0.52%, 20=19.42%, 50=0.05%
+ cpu : usr=1.50%, sys=3.96%, ctx=56755, majf=0, minf=43
+ IO depths : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
+ submit : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
+ complete : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
+ issued rwts: total=67336,0,0,0 short=0,0,0,0 dropped=0,0,0,0
+ latency : target=0, window=0, percentile=100.00%, depth=32
+
+Run status group 0 (all jobs):
+ READ: bw=52.5MiB/s (55.1MB/s), 26.3MiB/s-26.3MiB/s (27.5MB/s-27.5MB/s), io=526MiB (552MB), run=10013-10013msec
+
+Disk stats (read/write):
+ nvme0n1: ios=66595/0, merge=0/0, ticks=315688/0, in_queue=315688, util=99.06%
+ nvme0n2: ios=66597/0, merge=0/0, ticks=315684/0, in_queue=315683, util=99.06%
+"
+```

--- a/build/storage/recipes/nvme/fio.md
+++ b/build/storage/recipes/nvme/fio.md
@@ -29,12 +29,12 @@ Expected output
 ```
 connecting to 192.168.53.76:50051
 Rpc succeeded with OK status
-fioOutput: "iops-test-job: (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
+fioOutput: "job (/dev/nvme0n1): (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
 ...
 fio-3.29
 Starting 4 processes
 
-iops_test-job: (groupid=0, jobs=4): err= 0: pid=32: Thu Sep 22 11:04:43 2022
+job (/dev/nvme0n1): (groupid=0, jobs=4): err= 0: pid=32: Thu Sep 22 11:04:43 2022
  read: IOPS=21.4k, BW=83.4MiB/s (87.5MB/s)(84.5MiB/1013msec)
  slat (nsec): min=1127, max=12230k, avg=84547.05, stdev=780058.77
  clat (usec): min=2030, max=51525, avg=23478.74, stdev=6644.60

--- a/build/storage/recipes/virtio-blk/fio.md
+++ b/build/storage/recipes/virtio-blk/fio.md
@@ -27,12 +27,12 @@ Expected output
 ```
 connecting to 192.168.53.76:50051
 Rpc succeeded with OK status
-fioOutput: "iops-test-job: (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
+fioOutput: "job (/dev/vda): (g=0): rw=randrw, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=libaio, iodepth=256
 ...
 fio-3.29
 Starting 4 processes
 
-iops-test-job: (groupid=0, jobs=4): err= 0: pid=58: Tue May 31 15:43:41 2022
+job (/dev/vda): (groupid=0, jobs=4): err= 0: pid=58: Tue May 31 15:43:41 2022
  read: IOPS=20.9k, BW=81.8MiB/s (85.8MB/s)(82.2MiB/1005msec)
  slat (nsec): min=789, max=12745k, avg=93034.77, stdev=440827.15
  clat (usec): min=2708, max=81274, avg=23768.74, stdev=7565.45

--- a/build/storage/tests/ut/host-target/test_fio_args.py
+++ b/build/storage/tests/ut/host-target/test_fio_args.py
@@ -74,13 +74,10 @@ class FioArgsTests(unittest.TestCase):
         fio_args = FioArgs('{"name":"test"}')
         devices = ["/dev/nvme0n1", "/dev/nvme0n3"]
         fio_args.add_volumes_to_exercise(set(devices))
-        config_lines = []
+        content = ""
         with fio_args.create_config_file() as config:
             with open(config.file_name) as file:
-                config_lines = file.readlines()
+                content = file.read()
 
-        for line in config_lines:
-            if "filename" in line:
-                self.assertTrue(":".join(set(devices)) in line)
-                return
-        self.fail("No devices in fio config file")
+        self.assertTrue(f"[job ({devices[0]})]\nfilename={devices[0]}" in content)
+        self.assertTrue(f"[job ({devices[1]})]\nfilename={devices[1]}" in content)


### PR DESCRIPTION
In the previous version, if a fio is run to exercise all volumes attached to a device, all of them are exercised within a single job. However, it produced a joint report which does not show results for each volume separately. It can be inconvenient for the end user, if a per-volume statistic is needed.

In this patch, all volumes are exercised within their own fio job, and a separate report is shown for each device.