### PR TITLE
Pass spdk arguments outside of containers.

### DIFF
--- a/build/storage/core/ipu-storage-container/init
+++ b/build/storage/core/ipu-storage-container/init
@@ -13,7 +13,7 @@ IFS=' ' read -ra sock_path_line_content <<< "$(grep 'sock_path:' < /sma_config.y
 sock_path=${sock_path_line_content[1]}
 
 if [ -n "$sock_path" ]; then
-    export SPDK_ARGS=" -S $sock_path "
+    export SPDK_ARGS="$SPDK_ARGS -S $sock_path "
 fi
 
 # SPDK consumes many file descriptors if we create vhost user devices

--- a/build/storage/scripts/run_ipu_storage_container.sh
+++ b/build/storage/scripts/run_ipu_storage_container.sh
@@ -63,6 +63,7 @@ export IMAGE_NAME="ipu-storage-container"
 ARGS=()
 ARGS+=("-v" "${SHARED_VOLUME}:/${SHARED_VOLUME}")
 ARGS+=("-v" "${tmp_sma_config_file}:/sma_config.yml")
+ARGS+=("-e" "SPDK_ARGS=${SPDK_ARGS}")
 
 # shellcheck source=./scripts/run_container.sh
 # shellcheck disable=SC1091,SC1090

--- a/build/storage/scripts/run_storage_target_container.sh
+++ b/build/storage/scripts/run_storage_target_container.sh
@@ -40,6 +40,7 @@ export IMAGE_NAME="storage-target"
 ARGS=()
 ARGS+=("-e" "SPDK_IP_ADDR=${SPDK_IP_ADDR}")
 ARGS+=("-e" "SPDK_PORT=${SPDK_PORT}")
+ARGS+=("-e" "SPDK_ARGS=${SPDK_ARGS}")
 
 # shellcheck source=./scripts/run_container.sh
 # shellcheck disable=SC1091,SC1090


### PR DESCRIPTION
Storage-target and ipu-storage-container use SPDK inside. It can be useful to pass spdk arguments from upper level, for example to set core for reactor.
In this patch, SPDK arguments can be passed by means of SPDK_ARGS environment variable.