### PR TITLE
Disable kernel logs to print into console for storage vm.

### DIFF
--- a/build/storage/scripts/disk_infrastructure.py
+++ b/build/storage/scripts/disk_infrastructure.py
@@ -277,10 +277,6 @@ def create_nvme_device(
     )
     device_handle = response["handle"]
     if device_handle:
-        # At this moment qemu produces errors for a couple of seconds and
-        # it cannot handle other operations properly until all of them are
-        # printed.
-        time.sleep(2)
         if (
             os.system(
                 f'env -i no_grpc_proxy="" grpc_cli call \

--- a/build/storage/scripts/vm/prepare_vm.sh
+++ b/build/storage/scripts/vm/prepare_vm.sh
@@ -70,6 +70,8 @@ releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
     run_customize+=(--run-command "test -s $vm_host_target_tar_path")
     run_customize+=(--run-command "test -f /usr/local/bin/$run_host_target_container_script")
     run_customize+=(--run-command "test -f /usr/local/bin/$run_container_script")
+    run_customize+=(--run-command "echo 'kernel.printk = 0 0 0 0' > /etc/sysctl.conf")
+
 
     "${run_customize[@]}"
     mv "${vm_tmp_file}" "${DRIVE_TO_BOOT}"


### PR DESCRIPTION
Qemu with vfio-user actively produces logs and some of them were printed directly into console. Sometimes it could lead to incorrect device count, since devices printed into kernel logs were taken into account and delay was needed at device creation to mitigate that case.

After this patch, only emergency kernel logs will pop up into console.