### PR TITLE
Fix bandit warnings in storage code.

### DIFF
--- a/build/storage/core/host-target/fio_runner.py
+++ b/build/storage/core/host-target/fio_runner.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-#
-import subprocess
+
+# subprocess is needed to run fio
+import subprocess  # nosec
 from helpers.fio_args import FioArgs
 
 
@@ -14,7 +15,14 @@ def run_fio(fio_args: FioArgs):
     try:
         with fio_args.create_config_file() as config:
             fio_cmd = ["fio", config.file_name]
-            result = subprocess.run(fio_cmd, capture_output=True, text=True)
+            result = subprocess.run(
+                fio_cmd,
+                capture_output=True,
+                text=True,
+                # shell injection is prevented by shell=False, and FioArgs
+                # checks that device is not specified directly for fio
+                shell=False,  # nosec
+            )
             if result.returncode != 0:
                 raise FioExecutionError(
                     "fio execution error: '"

--- a/build/storage/core/host-target/sma_handle.py
+++ b/build/storage/core/host-target/sma_handle.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from pci  import PciAddress
+from pci import PciAddress
+
 
 class SmaHandleError(ValueError):
     pass

--- a/build/storage/tests/it/ptf_tests/system_tools/config.py
+++ b/build/storage/tests/it/ptf_tests/system_tools/config.py
@@ -21,7 +21,9 @@ class MainPlatformConfig(BaseConfig):
         self.password = os.getenv("MAIN_PLATFORM_PASSWORD")
         self.ip_address = os.getenv("MAIN_PLATFORM_IP_ADDRESS")
         self.port = os.getenv("MAIN_PLATFORM_PORT", 22)
-        self.workdir = os.getenv("MAIN_PLATFORM_WORKDIR", f"/home/{self.username}/workdir")
+        self.workdir = os.getenv(
+            "MAIN_PLATFORM_WORKDIR", f"/home/{self.username}/workdir"
+        )
 
 
 class StorageTargetConfig(MainPlatformConfig):
@@ -33,7 +35,9 @@ class StorageTargetConfig(MainPlatformConfig):
             self.password = os.getenv("STORAGE_TARGET_PASSWORD")
             self.ip_address = os.getenv("STORAGE_TARGET_IP_ADDRESS")
             self.port = os.getenv("STORAGE_TARGET_PORT", 22)
-            self.workdir = os.getenv("STORAGE_TARGET_WORKDIR", f"/home/{self.username}/workdir")
+            self.workdir = os.getenv(
+                "STORAGE_TARGET_WORKDIR", f"/home/{self.username}/workdir"
+            )
 
 
 class IPUStorageConfig(MainPlatformConfig):
@@ -45,7 +49,9 @@ class IPUStorageConfig(MainPlatformConfig):
             self.password = os.getenv("IPU_STORAGE_PASSWORD")
             self.ip_address = os.getenv("IPU_STORAGE_IP_ADDRESS")
             self.port = os.getenv("IPU_STORAGE_PORT", 22)
-            self.workdir = os.getenv("IPU_STORAGE_WORKDIR", f"/home/{self.username}/workdir")
+            self.workdir = os.getenv(
+                "IPU_STORAGE_WORKDIR", f"/home/{self.username}/workdir"
+            )
 
 
 class HostTargetConfig(MainPlatformConfig):
@@ -57,4 +63,6 @@ class HostTargetConfig(MainPlatformConfig):
             self.password = os.getenv("HOST_TARGET_PASSWORD")
             self.ip_address = os.getenv("HOST_TARGET_IP_ADDRESS")
             self.port = os.getenv("HOST_TARGET_PORT", 22)
-            self.workdir = os.getenv("HOST_TARGET_WORKDIR", f"/home/{self.username}/workdir")
+            self.workdir = os.getenv(
+                "HOST_TARGET_WORKDIR", f"/home/{self.username}/workdir"
+            )

--- a/build/storage/tests/it/ptf_tests/system_tools/test_platform.py
+++ b/build/storage/tests/it/ptf_tests/system_tools/test_platform.py
@@ -96,17 +96,17 @@ class BaseTestPlatform:
     def check_system_setup(self):
         """Overwrite this method in specific platform if you don't want check all setup"""
         if not self._is_virtualization():
-            raise Exception('Virtualization is not setting properly')
+            raise Exception("Virtualization is not setting properly")
         if not self._is_kvm():
-            raise Exception('KVM is not setting properly')
+            raise Exception("KVM is not setting properly")
         if not self.pms:
-            raise Exception('Packet manager is not setting properly')
+            raise Exception("Packet manager is not setting properly")
         if not self._is_qemu():
-            raise Exception('QUEMU is not setting properly')
+            raise Exception("QUEMU is not setting properly")
         if not self._set_security_policies():
-            raise Exception('Security polices is not setting properly')
+            raise Exception("Security polices is not setting properly")
         if not self._is_docker():
-            raise Exception('Docker is not setting properly')
+            raise Exception("Docker is not setting properly")
 
     # TODO: after testing restore settings
     def set_system_setup(self):
@@ -117,7 +117,6 @@ class BaseTestPlatform:
 
 
 class StorageTargetPlatform(BaseTestPlatform):
-
     def __init__(self):
         config = StorageTargetConfig()
         terminal = SSHTerminal(config)
@@ -129,11 +128,10 @@ class StorageTargetPlatform(BaseTestPlatform):
 
     # TODO add implementation
     def create_ramdrive(self):
-        return 'Guid'
+        return "Guid"
 
 
 class IPUStoragePlatform(BaseTestPlatform):
-
     def __init__(self):
         config = IPUStorageConfig()
         terminal = SSHTerminal(config)
@@ -141,11 +139,10 @@ class IPUStoragePlatform(BaseTestPlatform):
 
     # TODO add implementation
     def create_virtio_blk_device(self):
-        return 'VirtioBlkDevice'
+        return "VirtioBlkDevice"
 
 
 class HostTargetPlatform(BaseTestPlatform):
-
     def __init__(self):
         config = HostTargetConfig()
         terminal = SSHTerminal(config)
@@ -153,8 +150,8 @@ class HostTargetPlatform(BaseTestPlatform):
 
     # TODO add implementation
     def run_fio(self):
-        return 'FioOutput'
+        return "FioOutput"
 
     # TODO add implementation
     def check_number_of_virtio_blks(self):
-        return 'int'
+        return "int"

--- a/build/storage/tests/it/ptf_tests/tests/test_deploy_containers.py
+++ b/build/storage/tests/it/ptf_tests/tests/test_deploy_containers.py
@@ -12,7 +12,11 @@ from tests.steps.initial_steps import (
     RunIPUStorageContainer,
     RunStorageTargetContainer,
 )
-from system_tools.test_platform import HostTargetPlatform, IPUStoragePlatform, StorageTargetPlatform
+from system_tools.test_platform import (
+    HostTargetPlatform,
+    IPUStoragePlatform,
+    StorageTargetPlatform,
+)
 from test_connection import BaseTerminalMixin
 
 

--- a/build/storage/tests/ut/host-target/test_fake_sys_fs.py
+++ b/build/storage/tests/ut/host-target/test_fake_sys_fs.py
@@ -7,7 +7,7 @@
 
 import os
 from fake_pci_sys_fs import FakePciSysFs
-from pci  import PciAddress
+from pci import PciAddress
 from pyfakefs.fake_filesystem_unittest import TestCase
 from helpers.file_helpers import read_file
 

--- a/build/storage/tests/ut/host-target/test_pci_devices.py
+++ b/build/storage/tests/ut/host-target/test_pci_devices.py
@@ -5,7 +5,7 @@
 #
 
 from volumes import *
-from pci  import PciAddress, InvalidPciAddress
+from pci import PciAddress, InvalidPciAddress
 from volumes import VolumeId, VolumeError
 from pyfakefs.fake_filesystem_unittest import TestCase
 


### PR DESCRIPTION
Bandit warns about subprocess usage, which is vulnerable to shell injections. However, this module is needed to run fio against devices. The required parameters were added to avoid shell injections and bandit warnings were suppressed.