### PR TITLE
GitHub Workflow: changed ::set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Get processor architecture
       id: system 
       run: |
-        echo ::set-output name=arch::$(uname -m)
+        echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
 
     - name: Set up QEMU        
       uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Since `::set-output` has been deprecated this PR substitutes it with the newest output mechanism of GitHub workflow, in this way, we won't see the related warning in the Action.