### PR TITLE
Use explicit versions of vulnerable python packages.

### DIFF
--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -227,7 +227,8 @@ ARG HTTPS_PROXY
 ARG NO_PROXY
 
 # hadolint ignore=DL3013
-RUN dnf install -y python fio python3-pip && dnf clean all && python -m pip install --no-cache-dir grpcio-reflection pyfakefs
+RUN dnf install -y python fio python3-pip && dnf clean all && python -m pip install \
+    --no-cache-dir protobuf==3.20.2 grpcio-reflection pyfakefs
 
 COPY tests/ut/host-target /host-target/tests
 COPY --from=host-target /root /host-target/src/

--- a/build/storage/core/host-target/requirements.txt
+++ b/build/storage/core/host-target/requirements.txt
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-grpcio
-grpcio-tools
-grpcio-reflection
+protobuf==3.20.2
+grpcio==1.51.1
+grpcio-tools==1.48.2
+grpcio-reflection==1.48.2
 


### PR DESCRIPTION
Default protobuf version contains denial of service vulnerability described in SNYK-PYTHON-PROTOBUF-3031740.
Use explicit protobuf version 3.20.2 to overcome that issue. Use explicit host-target python packages to cover them by CI SNYK scans.