### PR TITLE
Fetch published images in storage scripts for manual scenarios

### DIFF
--- a/build/storage/scripts/build_container.sh
+++ b/build/storage/scripts/build_container.sh
@@ -31,7 +31,7 @@ host_target_image_tar="$script_dir/host-target.tar"
 
 function save_host_target_image_to_file() {
     local host_target_image_tar="$1"
-    FORCE_BUILD="true" "${script_dir}"/build_container.sh "host-target"
+    BUILD_IMAGE="true" "${script_dir}"/build_container.sh "host-target"
     docker save -o "$host_target_image_tar" host-target
 }
 

--- a/build/storage/scripts/run_cmd_sender.sh
+++ b/build/storage/scripts/run_cmd_sender.sh
@@ -7,7 +7,6 @@
 [ "$DEBUG" == 'true' ] && set -x
 
 export IMAGE_NAME="cmd-sender"
-export BUILD_IMAGE="true"
 scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 # shellcheck source=./scripts/run_container.sh

--- a/build/storage/scripts/run_container.sh
+++ b/build/storage/scripts/run_container.sh
@@ -22,8 +22,37 @@ if [ "$ALLOCATE_HUGEPAGES" == "true" ] ; then
     ARGS+=("-v" "/dev/hugepages:/dev/hugepages")
 fi
 
-if [ "$BUILD_IMAGE" == "true" ] ; then
-    bash "${scripts_dir}"/build_container.sh "$IMAGE_NAME"
+if [ "$DO_NOT_FETCH_OR_BUILD_IMAGE" == "true" ] ; then
+    echo "Image will not be fetched from remote registry or built locally."
+else
+    if [ "$BUILD_IMAGE" != "true" ] ; then
+        branch=$(git rev-parse --abbrev-ref HEAD)
+        if [ "$branch" == "main" ] ; then
+            echo "Image '$IMAGE_NAME' will be fetched from public registry."
+            commit_sha_with_changes_in_storage=$(git log --format=format:%h -n 1 -- "$scripts_dir/..")
+            arch=$(uname -m)
+            fetch_image_name="ghcr.io/ipdk-io/storage/$IMAGE_NAME-kvm-$arch:sha-$commit_sha_with_changes_in_storage"
+            if docker pull "$fetch_image_name" ; then
+                IMAGE_NAME="$fetch_image_name"
+            else
+                echo "Failed to fetch '$IMAGE_NAME' image."
+                BUILD_IMAGE="true"
+            fi
+        else
+            echo "Pre-built image fetch is available only for main branch versions."
+            BUILD_IMAGE="true"
+        fi
+    fi
+
+    if [ "$BUILD_IMAGE" == "true" ] ; then
+        echo "Building image '$IMAGE_NAME' locally."
+        if bash "${scripts_dir}"/build_container.sh "$IMAGE_NAME" ; then
+            echo "Image $IMAGE_NAME was built locally."
+        else
+            echo "Failed to build '$IMAGE_NAME' from local repo."
+            exit 1
+        fi
+    fi
 fi
 
 if [ "$AS_DAEMON" == "true" ] ; then

--- a/build/storage/scripts/run_host_target_container.sh
+++ b/build/storage/scripts/run_host_target_container.sh
@@ -37,10 +37,6 @@ function check_all_variables_are_set() {
 check_all_variables_are_set
 
 export IMAGE_NAME="host-target"
-if [[ "$FORCE_BUILD" == "true" || \
-     $(docker images --filter=reference='host-target' -q) == "" ]]; then
-    export BUILD_IMAGE="true"
-fi
 
 ARGS=()
 ARGS+=("-v" "/dev:/dev")
@@ -50,6 +46,12 @@ if [[ -n "$CUSTOMIZATION_DIR" ]]; then
     customization_dir_in_container="/customizations"
     ARGS+=("-v" "$(realpath "$CUSTOMIZATION_DIR"):$customization_dir_in_container")
     ARGS+=("-e" "CUSTOMIZATION_DIR_IN_CONTAINER=$customization_dir_in_container")
+
+    echo "Customization directoty is specified. Environment variable will be set to start a local build."
+    export BUILD_IMAGE="true"
+elif find "$scripts_dir/../core/host-target/customizations" -name '*.py' | grep '.py' ; then
+    echo "Python files are found in host-target customizations dir. Environment variable will be set to start a local build. "
+    export BUILD_IMAGE="true"
 fi
 
 # shellcheck source=./scripts/run_container.sh

--- a/build/storage/scripts/run_ipu_storage_container.sh
+++ b/build/storage/scripts/run_ipu_storage_container.sh
@@ -58,7 +58,6 @@ function cleanup() {
 trap 'cleanup' EXIT
 
 export ALLOCATE_HUGEPAGES="true"
-export BUILD_IMAGE="true"
 export IMAGE_NAME="ipu-storage-container"
 ARGS=()
 ARGS+=("-v" "${SHARED_VOLUME}:/${SHARED_VOLUME}")

--- a/build/storage/scripts/run_storage_target_container.sh
+++ b/build/storage/scripts/run_storage_target_container.sh
@@ -35,7 +35,6 @@ function check_all_variables_are_set() {
 check_all_variables_are_set
 
 export ALLOCATE_HUGEPAGES="true"
-export BUILD_IMAGE="true"
 export IMAGE_NAME="storage-target"
 ARGS=()
 ARGS+=("-e" "SPDK_IP_ADDR=${SPDK_IP_ADDR}")

--- a/build/storage/scripts/vm/prepare_vm.sh
+++ b/build/storage/scripts/vm/prepare_vm.sh
@@ -59,6 +59,7 @@ releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
     run_customize+=(--append-line "${systemd_host_target_service}:[Service]")
     run_customize+=(--append-line "${systemd_host_target_service}:Environment='PORT=${HOST_TARGET_SERVICE_PORT_IN_VM}'")
     run_customize+=(--append-line "${systemd_host_target_service}:Environment='WITHOUT_TTY=true'")
+    run_customize+=(--append-line "${systemd_host_target_service}:Environment='DO_NOT_FETCH_OR_BUILD_IMAGE=true'")
     run_customize+=(--append-line "${systemd_host_target_service}:ExecStart=run_host_target_container.sh")
     run_customize+=(--append-line "${systemd_host_target_service}:ExecStop=/bin/bash -c 'docker container rm -f \$(docker container ls  | grep host-target | awk \'{print \$1}\')'")
     run_customize+=(--append-line "${systemd_host_target_service}:[Install]")


### PR DESCRIPTION
All run_*_container.sh will try to fetch corresponding images from public IPDK registry first if git head is on main branch. This should improve user experience since no need to wait when images are built.

If building is preferable way to get images, then BUILD_IMAGE=true environment variable should be set.

If any customization for host-target is detected in default directory or specified in env var, local build we be run.

If it is needed to avoid fetching/building of images, DO_NOT_FETCH_OR_BUILD_IMAGE=true should be set.
