### PR TITLE
Rely on SPDK for QEMU install.

### DIFF
--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -169,17 +169,13 @@ RUN /scripts/vm/prepare_vm.sh
 FROM traffic-generator-env-vars AS traffic-generator
 
 RUN dnf install -y git glib2-devel libfdt-devel pixman-devel zlib-devel bzip2 \
-    ninja-build python3 make gcc diffutils && dnf clean all
-RUN git clone https://github.com/oracle/qemu /qemu-orcl
-WORKDIR /qemu-orcl
-RUN git checkout 46bb039c31e92ae84cf7fe1f64119c1a78e0d101 && \
-    git submodule update --init --recursive
-RUN ./configure --enable-multiprocess && make -j && make install
-WORKDIR /
-RUN rm -rf ./qemu-orcl
+    ninja-build python3 make gcc diffutils libaio-devel numactl-devel && \
+    dnf clean all
 COPY tests/it/traffic-generator/init /init
 COPY --from=traffic-generator-base $DRIVE_TO_BOOT $DRIVE_TO_BOOT
 COPY /scripts /scripts
+COPY /spdk/test/common/config/pkgdep/git /spdk/test/common/config/pkgdep/git
+RUN /scripts/vm/install_qemu.sh
 ENV SHARED_VOLUME=/ipdk-shared
 ENV UNIX_SERIAL=vm_socket
 ENTRYPOINT ["/init"]

--- a/build/storage/recipes/environment_setup.md
+++ b/build/storage/recipes/environment_setup.md
@@ -73,14 +73,21 @@ $ sudo chmod +r /boot/vmlinuz-*
 ```
 
 ### oracle/qemu
+Install required tools.
 ```
-$ git clone https://github.com/oracle/qemu qemu-orcl
-$ cd qemu-orcl
-$ git checkout 46bb039c31e92ae84cf7fe1f64119c1a78e0d101
-$ git submodule update --init --recursive
-$ ./configure --enable-multiprocess
-$ make
-$ make install
+$ dnf install -y git glib2-devel libfdt-devel pixman-devel zlib-devel bzip2 \
+    ninja-build python3 make gcc diffutils libaio-devel numactl-devel
+```
+or
+```
+$ apt install -y git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev \
+    ninja-build python3 make gcc libaio-dev libnuma-dev
+```
+
+Run the following script to install corresponding qemu version
+```
+$ scripts/prepare_to_build.sh
+$ scripts/vm/install_qemu.sh
 ```
 
 ## Setting security policies

--- a/build/storage/scripts/vm/install_qemu.sh
+++ b/build/storage/scripts/vm/install_qemu.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[ "$DEBUG" == 'true' ] && set -x
+set -e
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+scripts_dir="$script_dir/.."
+storage_dir="$scripts_dir/.."
+
+# shellcheck disable=SC1091,SC1090
+source "$script_dir/vm_default_variables.sh"
+
+ipdk_dir="/tmp/ipdk/storage"
+qemu_repo_dir="$ipdk_dir/qemu"
+mkdir -p "$qemu_repo_dir"
+function cleanup() {
+    rm -rf "$qemu_repo_dir"
+}
+trap "cleanup" SIGINT SIGTERM EXIT
+
+export GIT_REPOS="$qemu_repo_dir"
+# shellcheck disable=SC1091,SC1090
+source "$storage_dir/spdk/test/common/config/pkgdep/git"
+qemu_install_dir="/usr/local/qemu/$VFIO_QEMU_BRANCH"
+
+if [ -e "$QEMU_BINARY" ] ; then
+    echo "QEMU is already installed, removing"
+    sudo rm -f "$QEMU_BINARY"
+    sudo rm -rf "$qemu_install_dir"
+fi
+
+_install_qemu "$GIT_REPO_QEMU_VFIO" "$VFIO_QEMU_BRANCH"
+sudo ln -s "$qemu_install_dir/bin/qemu-system-x86_64" "$QEMU_BINARY"

--- a/build/storage/scripts/vm/run_vm.sh
+++ b/build/storage/scripts/vm/run_vm.sh
@@ -8,7 +8,8 @@
 
 set -e
 
-scripts_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/..
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+scripts_dir="$script_dir/.."
 # shellcheck disable=SC1091,SC1090
 source "$scripts_dir"/vm/vm_default_variables.sh
 
@@ -27,7 +28,7 @@ export HOST_TARGET_SERVICE_PORT_IN_VM
 "${scripts_dir}"/vm/prepare_vm.sh
 "${scripts_dir}"/allocate_hugepages.sh
 
-run_vm="sudo qemu-system-x86_64 \
+run_vm="sudo $QEMU_BINARY \
   ${qemu_serial} \
   --enable-kvm \
   -cpu host \

--- a/build/storage/scripts/vm/vm_default_variables.sh
+++ b/build/storage/scripts/vm/vm_default_variables.sh
@@ -10,3 +10,4 @@ export DEFAULT_QMP_PORT=5555
 export DEFAULT_QMP_ADDRESS="0.0.0.0"
 export IPDK_PCI_BRIDGE_0="pci.ipdk.0"
 export IPDK_PCI_BRIDGE_1="pci.ipdk.1"
+export QEMU_BINARY="/usr/local/qemu/qemu-system-x86_64"


### PR DESCRIPTION
IPDK relies on SPDK to cover KVM capabilities. To avoid any issues, IPDK should rely on the same version of QEMU used by SPDK.
