### PR TITLE
Eliminate shell calls in storage.

### DIFF
--- a/build/storage/Dockerfile
+++ b/build/storage/Dockerfile
@@ -223,10 +223,13 @@ ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
 
+WORKDIR /
 RUN dnf install -y socat-1.7.4.2-2.fc36 \
     grpc-cli-1.41.1-21.fc36 \
     jq-1.6-13.fc36 && \
     dnf clean all
+COPY core/cmd-sender/requirements.txt ./
+RUN python -m pip install --no-cache-dir -r ./requirements.txt
 
 COPY tests/it/test-drivers/test-helpers /test-helpers
 COPY scripts/ /scripts

--- a/build/storage/core/cmd-sender/requirements.txt
+++ b/build/storage/core/cmd-sender/requirements.txt
@@ -1,0 +1,5 @@
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+grpc-requests==0.1.7
+urllib3==1.26.5


### PR DESCRIPTION
Shell was used in storage to call grpc_cli tool. However, shell calls are treated as unsafe by some code scanners and they have to be replaced with some more reliable approaches.
