### PR TITLE
Provide security-related notes to crypto recipe.

### DIFF
--- a/build/storage/recipes/environment_setup.md
+++ b/build/storage/recipes/environment_setup.md
@@ -50,10 +50,14 @@ Installation guideline for [Fedora](https://docs.docker.com/engine/install/fedor
 
 Installation guideline for [Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 
-**Note:**
+---
+**NOTE**
+
 Make sure that required proxy settings are configured for docker.
 Please, refer to [this](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
 page.
+
+---
 
 ### libguestfs-tools
 ```
@@ -64,13 +68,16 @@ or
 $ sudo apt install libguestfs-tools
 ```
 
-**Note:**
+---
+**NOTE**
+
 To run `libguestfs` tools without root privileges, you may need to workaround
-the problem of
-Linux kernel image not being readable by issuing:
+the problem of Linux kernel image not being readable by issuing:
 ```
 $ sudo chmod +r /boot/vmlinuz-*
 ```
+
+---
 
 ### oracle/qemu
 Install required tools.
@@ -123,11 +130,16 @@ scripts/run_ipu_storage_container.sh
 `SHARED_VOLUME` points to a directory where vhost storage devices
 will be exposed.
 
-**Note:** By default, images for `storage-target` and `ipu-storage-container`
+---
+**NOTE**
+
+By default, images for `storage-target` and `ipu-storage-container`
 will be pulled from IPDK public registry for the scripts in the main branch.
 However, those images are not optimized for a local CPU and if such an
 optimization is required, then `OPTIMIZED_SPDK=true` environment variable should
 be exported before running the scripts above.
+
+---
 
 It is also possible for `storage-target` to specify ip addresses and ports where
 spdk service is exposed on by specifying `SPDK_IP_ADDR` and `SPDK_PORT`

--- a/build/storage/recipes/nvme/crypto.md
+++ b/build/storage/recipes/nvme/crypto.md
@@ -2,6 +2,18 @@
 
 This recipe describes how to create crypto volumes for NVMe devices.
 
+---
+**NOTE**
+
+Please note that the recipe does not provide a solution for opening a secure connection for the provisioning
+of crypto keys. In particular, the crypto keys provided by the user in plain text will be passed through between
+the `cmd-sender` and `ipu-storage-container` which consumes them (both running on `ipu-storage-container-platform`).
+Secret generation, management and provisioning are not part of this recipe and are the responsibility of the end
+user to integrate the solution securely with their own production environment so that data confidentiality,
+integrity and availability are assured.
+
+---
+
 For this recipe, two physical machines are required.
 They are referred to as `storage-target-platform` and `ipu-storage-container-platform`.
 The containers running on those platforms are named `storage-target` and
@@ -21,9 +33,14 @@ $ attach_crypto_volume_with_aes_cbc_cipher <ipu_storage_container_platform_ip> "
 ```
 `1234567890abcdef1234567890abcde1` can be replaced with any other suitable key.
 
-Note: Underlying SMA supports also AES XTS cipher. If a used platform supports that cipher,
+---
+**NOTE**
+
+Underlying SMA supports also AES XTS cipher. If the platform in use supports that cipher,
 `attach_crypto_volume_with_aes_xts_cipher` can be used to attach a crypto volume.
-In addition, after the key, an additional key2 should be specified.
+In that case, in addition to key, a second key2 needs to be provided as required by the cipher.
+
+---
 
 4. Fill in drive with a pattern
 Send from your `cmd-sender`


### PR DESCRIPTION
Crypto recipe is extended with an important note to the end-user regarding the solution since crypto keys are passed in plain text between the containers.

Signed-off-by: Filip Szufnarowski <filip.szufnarowski@intel.com>