### PR TITLE
Minimize container OS distro packages installation and container run …

### DIFF
--- a/build/networking/scripts/distro_pkg_install.sh
+++ b/build/networking/scripts/distro_pkg_install.sh
@@ -97,7 +97,8 @@ fedora_install_deployment_pkgs() {
 
 fedora_install_default_pkgs() {
     echo "Installing packages required for runtime"
-    dnf install -y boost-iostreams \
+    dnf install -y --setopt=install_weak_deps=False \
+        boost-iostreams \
         boost-devel \
         gmp-devel \
         numactl-devel \
@@ -229,8 +230,9 @@ ubuntu_install_deployment_pkgs() {
 
 ubuntu_install_default_pkgs() {
     echo "Installing packages required for runtime"
-    apt-get update
-    apt-get install -y libboost-iostreams-dev \
+    apt-get update --assume-yes --no-install-suggests --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+    apt-get install -y --no-install-suggests --no-install-recommends -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
+        libboost-iostreams-dev \
         libboost-dev \
         libgmp-dev \
         libgc-dev \
@@ -245,10 +247,10 @@ ubuntu_install_default_pkgs() {
         sudo \
         net-tools \
         iproute2 \
-        vim \
         iputils-ping \
         psmisc \
-        openssl
+        openssl \
+        gcc
 
     python3 -m pip install --no-cache-dir --upgrade pip
     python3 -m pip install --no-cache-dir grpcio

--- a/build/scripts/ipdk.sh
+++ b/build/scripts/ipdk.sh
@@ -266,11 +266,14 @@ start_container() {
 	docker "${RUNCMD[@]}" \
 		--name "${CONTAINER_NAME}" \
 		--rm \
-		--cap-add ALL \
 		--privileged \
 		-v "${VOLUME}":/tmp \
 		-p 9339:9339 \
 		-p 9559:9559 \
+		--pids-limit="${PIDS_LIMIT}" \
+		--cpu-shares="${CPU_SHARES}" \
+		--memory="${MEMORY}" \
+		--security-opt="${SECURITY_OPT_NO_NEW_PRIV}" \
 		"${ARGS[@]}" -it "${IMAGE_NAME}":"${TAG}" "${RUN_COMMAND[@]}"
 
 	if [ "$LINK_NAMESPACE" ] ; then

--- a/build/scripts/ipdk_default.env
+++ b/build/scripts/ipdk_default.env
@@ -48,3 +48,9 @@ SOCKET=""                               # Name of the socket to create in
 # KVM VMs startup parameters
 KVM_GRAPHIC=false                       # Start KVM basd VM with X-Window
                                         # (true/false)
+
+# Container bring up options for best practices
+PIDS_LIMIT="${PIDS_LIMIT:-1024}"
+CPU_SHARES="${CPU_SHARES:-1024}"
+MEMORY="${MEMORY:-4096m}"
+SECURITY_OPT_NO_NEW_PRIV="no-new-privileges"


### PR DESCRIPTION
…options

Add apt-get and dnf options to minimize or avoid recommended and suggested packages while creating container images.
Added few container run options needed for container bring up best practices.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>