### PR TITLE
Add openssl package required for gRPC TLS

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - main
       - ipdk_v*
-      paths:
+    paths:
       - 'build/networking/**'
       - 'build/networking_ebpf/**'
       - 'build/scripts/**'

--- a/build/networking/scripts/distro_pkg_install.sh
+++ b/build/networking/scripts/distro_pkg_install.sh
@@ -50,6 +50,7 @@ fedora_install_build_pkgs() {
         openssl-devel \
         libatomic \
         libnl3-devel \
+        openssl \
         which
 
     python -m pip install --upgrade pip
@@ -80,6 +81,7 @@ fedora_install_deployment_pkgs() {
         procps-ng \
         iproute \
         net-tools \
+        openssl \
         iputils
 
     python -m pip install --upgrade pip
@@ -177,6 +179,7 @@ ubuntu_install_build_pkgs() {
         wget \
         vim \
         numactl \
+        openssl \
         sudo \
         "${PYTHON_PKG_NAME}"
 
@@ -213,6 +216,7 @@ ubuntu_install_deployment_pkgs() {
         sudo \
         net-tools \
         iproute2 \
+        openssl \
         vim
 
     python3 -m pip install --no-cache-dir --upgrade pip


### PR DESCRIPTION
Modified distro packages installation script to include openssl package required for gRPC TLS client-server communication.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>