### PR TITLE
Removing docker linting for storage dockerfile

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,12 +19,3 @@ jobs:
       - uses: avto-dev/markdown-lint@v1.5.0
         with:
           args: '--config ./linters/mdl_config.yml ./*.md'
-
-  docker-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: hadolint/hadolint-action@v2.1.0
-        with:
-          recursive: true
-          ignore: DL3041


### PR DESCRIPTION
- Cleanup of docker linting from ipdk_v23.07 branch as part of storage source code clean from 23.07 branch
