### PR TITLE
Update p4c, psde and infrap4d SHA for 23.07 release

### DIFF
--- a/build/networking/scripts/build_p4c.sh
+++ b/build/networking/scripts/build_p4c.sh
@@ -27,7 +27,7 @@ eval set -- "${GETOPTS}"
 WORKING_DIR=""
 DEPS_INSTALL_DIR=""
 # Default release SHA
-GIT_SHA="e052f1fbe9cb18c705203637ddb3f36624222a87"
+GIT_SHA="a73a7fc2d6f98c0ae1f1eb7dde51e856d3f2f53e"
 NUM_CORES=4
 
 # Process command-line options.

--- a/build/networking/scripts/build_p4sde.sh
+++ b/build/networking/scripts/build_p4sde.sh
@@ -29,7 +29,7 @@ eval set -- "${GETOPTS}"
 # Set defaults.
 WORKING_DIR=""
 # Default release SHA
-GIT_SHA="199d418f5fcfaca7fb7992d4867e72b39ebe6e31"
+GIT_SHA="05e53e3210ed81359af743b3b6d02fe445ec5bfa"
 NUM_CORES=4
 SDE_DIR_NAME="p4-sde"
 SDE_SRC_DIR_NAME="p4-driver"

--- a/build/networking/scripts/download_nr_src_code.sh
+++ b/build/networking/scripts/download_nr_src_code.sh
@@ -24,7 +24,7 @@ eval set -- "${GETOPTS}"
 # Set defaults.
 WORKING_DIR=""
 # Default SHA or GIT branch
-GIT_SHA="ipdk_v23.01"
+GIT_SHA="ipdk_v23.07"
 NR_DIR="networking-recipe"
 
 # Process command-line options.


### PR DESCRIPTION
Updating the `main` branch with the 23.07 release image SHA values for building networking-recipe container