### PR TITLE
Update networking container to fix unused p4c flag & add new dependencies

### DIFF
--- a/build/networking/scripts/build_p4c.sh
+++ b/build/networking/scripts/build_p4c.sh
@@ -94,7 +94,6 @@ git submodule update --init --recursive
 mkdir build && mkdir -p "${WORKING_DIR}"/p4c/install && cd build
 
 cmake -DCMAKE_INSTALL_PREFIX="${WORKING_DIR}"/p4c/install \
-  -DENABLE_BMV2=OFF \
   -DENABLE_EBPF=OFF \
   -DENABLE_UBPF=OFF \
   -DENABLE_GTESTS=OFF \

--- a/build/networking/scripts/distro_pkg_install.sh
+++ b/build/networking/scripts/distro_pkg_install.sh
@@ -55,6 +55,7 @@ fedora_install_build_pkgs() {
 
     python -m pip install --upgrade pip
     python -m pip install grpcio
+    python -m pip install netaddr
     python -m pip install ovspy
     python -m pip install protobuf==3.20.3
     python -m pip install p4runtime
@@ -86,6 +87,7 @@ fedora_install_deployment_pkgs() {
 
     python -m pip install --upgrade pip
     python -m pip install grpcio
+    python -m pip install netaddr
     python -m pip install ovspy
     python -m pip install protobuf==3.20.3
     python -m pip install p4runtime
@@ -119,6 +121,7 @@ fedora_install_default_pkgs() {
 
     python -m pip install --upgrade pip
     python -m pip install grpcio
+    python -m pip install netaddr
     python -m pip install ovspy
     python -m pip install protobuf==3.20.3
     python -m pip install p4runtime
@@ -185,6 +188,7 @@ ubuntu_install_build_pkgs() {
 
     python3 -m pip install --no-cache-dir --upgrade pip
     python3 -m pip install --no-cache-dir grpcio
+    python3 -m pip install --no-cache-dir netaddr
     python3 -m pip install --no-cache-dir ovspy \
         protobuf=="${PROTOBUF_VER}" \
         p4runtime \
@@ -221,6 +225,7 @@ ubuntu_install_deployment_pkgs() {
 
     python3 -m pip install --no-cache-dir --upgrade pip
     python3 -m pip install --no-cache-dir grpcio
+    python3 -m pip install --no-cache-dir netaddr
     python3 -m pip install --no-cache-dir ovspy \
         protobuf=="${PROTOBUF_VER}" \
         p4runtime
@@ -258,6 +263,7 @@ ubuntu_install_default_pkgs() {
 
     python3 -m pip install --no-cache-dir --upgrade pip
     python3 -m pip install --no-cache-dir grpcio
+    python3 -m pip install --no-cache-dir netaddr
     python3 -m pip install --no-cache-dir ovspy \
         protobuf=="${PROTOBUF_VER}" \
         p4runtime


### PR DESCRIPTION
Address two build issues:
   > Missing 'netaddr' module. Updated install script to provide it.
   > Compile errors in P4C. The latest P4C compiler uses some code from bmv2 , so it shouldn't be disabled. Removed 
       ENABLE_BMV2=OFF from the cmake command. Verified with compiler team that this is correct.