### PR TITLE
Update links in networking README

### DIFF
--- a/build/networking/README.md
+++ b/build/networking/README.md
@@ -39,8 +39,5 @@ by the gRPC Server and Client for secure communication.
 ## Helpful references:
 
 1. [Networking Recipe](https://github.com/ipdk-io/networking-recipe/blob/main/README.md)
-2. [Networking Recipe Build Instructions](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/dpdk-guide.md)
-3. [P4RT-CTL P4runtime Client](https://github.com/ipdk-io/networking-recipe/blob/main/docs/clients/p4rt-ctl.rst)
-4. [GNMI-CTL Port Configuration Client](https://github.com/ipdk-io/networking-recipe/blob/main/docs/clients/gnmi-ctl.rst)
-5. [gRPC TLS Security](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/security-guide.md)
-6. [Sample P4 Program](https://github.com/ipdk-io/ipdk/blob/main/build/networking/examples/simple_l3/simple_l3.p4)
+2. [P4 Control Plane User Guide](https://ipdk.io/p4cp-userguide/)
+3. [Sample P4 Program](https://github.com/ipdk-io/ipdk/blob/main/build/networking/examples/simple_l3/simple_l3.p4)

--- a/build/networking/README.md
+++ b/build/networking/README.md
@@ -28,7 +28,7 @@ and the server (`infrap4d`) for:
 
 By default, this gRPC communication is secure. You have the option to use
 insecure mode, if you wish. See the 
-[security guide](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/security-guide.md)
+[security guide](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/security/security-guide.md)
 for more information.
 
 IPDK includes a script
@@ -36,7 +36,7 @@ IPDK includes a script
 to generate certificates and copy them to a specific location that will be used
 by the gRPC Server and Client for secure communication.
 
-## Helpful references:
+## Helpful references
 
 1. [Networking Recipe](https://github.com/ipdk-io/networking-recipe/blob/main/README.md)
 2. [P4 Control Plane User Guide](https://ipdk.io/p4cp-userguide/)

--- a/build/networking/README.md
+++ b/build/networking/README.md
@@ -28,7 +28,7 @@ and the server (`infrap4d`) for:
 
 By default, this gRPC communication is secure. You have the option to use
 insecure mode, if you wish. See the 
-[security guide](https://github.com/ipdk-io/networking-recipe/blob/main/docs/guides/security/security-guide.md)
+[security guide](https://ipdk.io/p4cp-userguide/guides/security/security-guide.html)
 for more information.
 
 IPDK includes a script


### PR DESCRIPTION
- Replace links to individual documents with a link to the P4 Control Plane User Guide.
- Correct link to security guide.